### PR TITLE
feat: add contact page and surface email across site (TEC-188)

### DIFF
--- a/app/components/CommandPalette.tsx
+++ b/app/components/CommandPalette.tsx
@@ -36,6 +36,11 @@ const pagesLinks = [
         label: 'Services'
     },
     {
+        to: '/contact',
+        icon: LinkIcon,
+        label: 'Contact'
+    },
+    {
         to: '/til',
         icon: LinkIcon,
         label: 'TIL'

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -8,3 +8,5 @@ export enum ContentStyles {
     FRONTEND = `Design`,
     CURRENT_JOB_TITLE = `Design Technologist`
 }
+
+export const CONTACT_EMAIL = 'sethdavis512@gmail.com';

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -11,6 +11,7 @@ export default [
         route('about', 'routes/about.tsx'),
         route('services', 'routes/services.tsx'),
         route('services/:slug', 'routes/service-detail.tsx'),
+        route('contact', 'routes/contact.tsx'),
         route('til', 'routes/til.tsx'),
         route('til/:slug', 'routes/til-detail.tsx'),
         route('resume', 'routes/resume.tsx'),

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -7,6 +7,7 @@ import { Heading } from '~/components/Heading';
 import { Linky } from '~/components/Linky';
 import type { Route } from './+types/about';
 import { Button } from '~/components/Button';
+import { CONTACT_EMAIL } from '~/constants';
 
 export function meta() {
     return generateRouteMeta({
@@ -175,14 +176,20 @@ export default function AboutRoute({ loaderData }: Route.ComponentProps) {
                     Check out projects where I put these values into practice,
                     or get in touch to discuss working together.
                 </p>
-                <div className="flex gap-4">
+                <div className="flex flex-wrap gap-4">
                     <Button to="/work" size="lg">
                         See my work
                     </Button>
-                    <Button to="/services" size="lg" variant="outline">
+                    <Button to="/contact" size="lg" variant="outline">
                         Get in touch
                     </Button>
                 </div>
+                <p className="mt-6 text-zinc-400">
+                    Or email me directly at{' '}
+                    <Linky href={`mailto:${CONTACT_EMAIL}`}>
+                        {CONTACT_EMAIL}
+                    </Linky>
+                </p>
             </section>
             <hr className="border-zinc-500 my-12" />
             <Heading as="h2" className="mb-8">

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -1,0 +1,220 @@
+import { ArrowRight, LoaderIcon, Mail } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { data, useFetcher } from 'react-router';
+
+import { Button } from '~/components/Button';
+import { FormAlert } from '~/components/FormAlert';
+import { FormField } from '~/components/FormField';
+import { Heading } from '~/components/Heading';
+import { Linky } from '~/components/Linky';
+import { CodepenLogo } from '~/components/logos/CodepenLogo';
+import { GitHubLogo } from '~/components/logos/GitHubLogo';
+import { LinkedInLogo } from '~/components/logos/LinkedInLogo';
+import { XLogo } from '~/components/logos/XLogo';
+import { CONTACT_EMAIL } from '~/constants';
+import { getPortfolioBase } from '~/airtable';
+import { validateContactForm } from '~/schemas/contact';
+import { generateRouteMeta } from '~/utils/seo';
+import type { ContactFieldErrors } from '~/schemas/contact';
+import type { Route } from './+types/contact';
+
+export function meta() {
+    return generateRouteMeta({
+        pageTitle: 'Contact',
+        descriptionContent:
+            'Get in touch with Seth Davis. Email directly, book a call, or send a message about a role, project, or collaboration.',
+        ogUrl: 'https://sethdavis.tech/contact'
+    });
+}
+
+export async function action({ request }: Route.ActionArgs) {
+    const formData = await request.formData();
+    const validation = validateContactForm(formData);
+
+    if (!validation.success) {
+        return data({ fieldErrors: validation.fieldErrors }, { status: 400 });
+    }
+
+    try {
+        const response = await getPortfolioBase()('Customers').create([
+            {
+                fields: {
+                    'First name': validation.data.firstName,
+                    'Last name': validation.data.lastName,
+                    Email: validation.data.email,
+                    Note: validation.data.note || '',
+                    Offer: validation.data.offer || 'general-contact'
+                }
+            }
+        ]);
+
+        if (!response || response.length === 0) {
+            throw new Error('No record created in Airtable');
+        }
+
+        return data({ success: true }, { status: 200 });
+    } catch (error) {
+        console.error('Error saving contact message:', error);
+
+        return data(
+            {
+                error: 'There was an error sending your message. Please try again later.'
+            },
+            { status: 500 }
+        );
+    }
+}
+
+interface ContactActionData {
+    success?: boolean;
+    error?: string;
+    fieldErrors?: ContactFieldErrors;
+}
+
+const socials = [
+    { href: 'https://github.com/sethdavis512', label: 'GitHub', Logo: GitHubLogo },
+    {
+        href: 'https://www.linkedin.com/in/sethdavis512/',
+        label: 'LinkedIn',
+        Logo: LinkedInLogo
+    },
+    { href: 'https://www.x.com/sethdavis512/', label: 'X (Twitter)', Logo: XLogo },
+    {
+        href: 'https://www.codepen.io/sethdavis512/',
+        label: 'CodePen',
+        Logo: CodepenLogo
+    }
+];
+
+export default function ContactRoute() {
+    const fetcher = useFetcher<ContactActionData>();
+    const formRef = useRef<HTMLFormElement>(null);
+
+    useEffect(() => {
+        if (fetcher.data?.success && formRef.current) {
+            formRef.current.reset();
+        }
+    }, [fetcher.data]);
+
+    return (
+        <article className="max-w-3xl mx-auto space-y-12">
+            <section>
+                <Heading as="h1" className="mb-4">
+                    Get in touch
+                </Heading>
+                <p className="text-lg text-zinc-300 mb-8">
+                    Hiring, a project, or just want to compare notes? The fastest
+                    way to reach me is email. Prefer a form? There's one below and
+                    it lands straight in my inbox.
+                </p>
+                <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+                    <a
+                        href={`mailto:${CONTACT_EMAIL}`}
+                        className="inline-flex items-center gap-2 rounded-lg bg-primary-500/15 hover:bg-primary-500/25 text-primary-300 hover:text-primary-200 transition-colors duration-200 px-4 py-3 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+                    >
+                        <Mail className="size-5" />
+                        {CONTACT_EMAIL}
+                    </a>
+                    <Linky href="https://tidycal.com/sethdavis512/meet-and-greet">
+                        Or book a 30-minute call
+                    </Linky>
+                </div>
+                <div className="mt-8 flex items-center gap-6">
+                    {socials.map(({ href, label, Logo }) => (
+                        <Linky key={href} href={href} aria-label={label}>
+                            <Logo className="w-7 h-7" />
+                        </Linky>
+                    ))}
+                </div>
+            </section>
+
+            <section
+                id="message"
+                className="rounded-xl bg-gradient-to-br from-zinc-900 via-zinc-900 to-primary-950/40 border border-zinc-800 p-8 md:p-10"
+            >
+                <div className="max-w-xl mb-6">
+                    <Heading as="h2" size="3" className="mb-3">
+                        Send a message
+                    </Heading>
+                    <p className="text-zinc-300">
+                        Tell me a bit about what you have in mind. I read every
+                        message and reply within one business day.
+                    </p>
+                </div>
+                <fetcher.Form
+                    method="POST"
+                    className="space-y-4 max-w-xl"
+                    ref={formRef}
+                >
+                    <input
+                        type="hidden"
+                        name="offer"
+                        value="general-contact"
+                    />
+                    {fetcher.data?.success ? (
+                        <FormAlert variant="success">
+                            Thanks for reaching out. Your message is in. I'll be
+                            in touch within one business day.
+                        </FormAlert>
+                    ) : fetcher.data?.error ? (
+                        <FormAlert variant="error">
+                            There was an error sending your message.
+                            <br />
+                            Please try again later.
+                        </FormAlert>
+                    ) : null}
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <FormField
+                            label="First name"
+                            name="firstName"
+                            required
+                            placeholder="Your first name"
+                            error={fetcher.data?.fieldErrors?.firstName}
+                        />
+                        <FormField
+                            label="Last name"
+                            name="lastName"
+                            required
+                            placeholder="Your last name"
+                            error={fetcher.data?.fieldErrors?.lastName}
+                        />
+                    </div>
+                    <FormField
+                        label="Email address"
+                        name="email"
+                        type="email"
+                        required
+                        placeholder="you@example.com"
+                        error={fetcher.data?.fieldErrors?.email}
+                    />
+                    <FormField
+                        label="What's on your mind?"
+                        name="note"
+                        as="textarea"
+                        required
+                        rows={5}
+                        placeholder="A role, a project, an idea, a question..."
+                        error={fetcher.data?.fieldErrors?.note}
+                    />
+                    <Button
+                        type="submit"
+                        size="lg"
+                        disabled={fetcher.state !== 'idle'}
+                        iconBefore={
+                            fetcher.state !== 'idle' ? (
+                                <LoaderIcon className="animate-spin size-4" />
+                            ) : undefined
+                        }
+                        iconAfter={
+                            fetcher.state === 'idle' ? (
+                                <ArrowRight className="size-4" />
+                            ) : undefined
+                        }
+                    >
+                        {fetcher.state !== 'idle' ? 'Sending...' : 'Send message'}
+                    </Button>
+                </fetcher.Form>
+            </section>
+        </article>
+    );
+}

--- a/app/routes/resume.tsx
+++ b/app/routes/resume.tsx
@@ -1,9 +1,9 @@
 import { cx } from '~/cva.config';
-import { InfoIcon } from 'lucide-react';
+import { InfoIcon, MailIcon } from 'lucide-react';
 import type { PropsWithChildren } from 'react';
 
 import { Banner } from '~/components/Banner';
-import { ContentStyles } from '~/constants';
+import { CONTACT_EMAIL, ContentStyles } from '~/constants';
 import { Flex } from '~/components/Flex';
 import { skills } from '~/content/data/skills';
 import { generateRouteMeta } from '~/utils/seo';
@@ -45,7 +45,7 @@ export default function ResumeRoute({ loaderData }: Route.ComponentProps) {
             <Heading as="h1" className="mb-8">
                 Resume
             </Heading>
-            <Banner className="mb-8">
+            <Banner className="mb-4">
                 <Flex>
                     <InfoIcon />
                     Looking for a PDF version?{' '}
@@ -54,6 +54,20 @@ export default function ResumeRoute({ loaderData }: Route.ComponentProps) {
                     </Linky>
                 </Flex>
             </Banner>
+            <div className="mb-8 flex flex-col sm:flex-row sm:items-center gap-x-4 gap-y-2 text-zinc-300">
+                <a
+                    href={`mailto:${CONTACT_EMAIL}`}
+                    className="inline-flex items-center gap-2 font-medium text-zinc-100 hover:text-primary-400 transition-colors duration-200 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+                >
+                    <MailIcon className="size-4" />
+                    {CONTACT_EMAIL}
+                </a>
+                <span className="hidden sm:inline text-zinc-600">·</span>
+                <span>
+                    Hiring or have a project?{' '}
+                    <Linky to="/contact">Send me a message</Linky>
+                </span>
+            </div>
             <ResumeSection>
                 <Heading as="h2" size="2">
                     Summary

--- a/app/routes/wrapper.tsx
+++ b/app/routes/wrapper.tsx
@@ -1,12 +1,16 @@
 import { cx } from '~/cva.config';
-import { MenuIcon } from 'lucide-react';
+import { MailIcon, MenuIcon } from 'lucide-react';
 import { useReducer } from 'react';
 import { Link, NavLink, Outlet } from 'react-router';
 import { Button } from '~/components/Button';
 import { Flex } from '~/components/Flex';
 import { KeyboardShortcut } from '~/components/KeyboardShortcut';
+import { Linky } from '~/components/Linky';
+import { GitHubLogo } from '~/components/logos/GitHubLogo';
+import { LinkedInLogo } from '~/components/logos/LinkedInLogo';
 import { Logo } from '~/components/logos/SethDavisLogo';
-import { BorderStyles } from '~/constants';
+import { XLogo } from '~/components/logos/XLogo';
+import { BorderStyles, CONTACT_EMAIL } from '~/constants';
 
 const sharedLinkClasses = `text-4xl md:text-lg`;
 
@@ -53,6 +57,12 @@ const NAV_ITEMS: NavItem[] = [
         to: '/about',
         label: 'About',
         ariaLabel: 'Learn more about me'
+    },
+    {
+        type: 'internal',
+        to: '/contact',
+        label: 'Contact',
+        ariaLabel: 'Get in touch with me'
     },
     {
         type: 'external',
@@ -253,8 +263,47 @@ export default function WrapperRoute() {
                 </Container>
             </main>
             <footer className="py-0 md:py-8">
-                <Container className="flex flex-col items-center gap-4">
-                    <div className="flex w-full items-center justify-between my-12">
+                <Container className="flex flex-col items-center gap-8">
+                    <div className="flex flex-col items-center gap-5 mt-12">
+                        <a
+                            href={`mailto:${CONTACT_EMAIL}`}
+                            className="inline-flex items-center gap-2 text-lg font-medium text-zinc-700 dark:text-zinc-200 hover:text-primary-500 dark:hover:text-primary-400 transition-colors duration-200 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+                        >
+                            <MailIcon className="size-5" />
+                            {CONTACT_EMAIL}
+                        </a>
+                        <div className="flex items-center gap-6">
+                            <Linky
+                                to="/contact"
+                                variant="muted"
+                                className="text-sm"
+                            >
+                                Contact
+                            </Linky>
+                            <Linky
+                                href="https://github.com/sethdavis512"
+                                aria-label="GitHub"
+                                variant="muted"
+                            >
+                                <GitHubLogo className="w-6 h-6" />
+                            </Linky>
+                            <Linky
+                                href="https://www.linkedin.com/in/sethdavis512/"
+                                aria-label="LinkedIn"
+                                variant="muted"
+                            >
+                                <LinkedInLogo className="w-6 h-6" />
+                            </Linky>
+                            <Linky
+                                href="https://www.x.com/sethdavis512/"
+                                aria-label="X (Twitter)"
+                                variant="muted"
+                            >
+                                <XLogo className="w-6 h-6" />
+                            </Linky>
+                        </div>
+                    </div>
+                    <div className="flex w-full items-center justify-between mb-12">
                         <div className={`flex-grow ${BorderStyles.BOTTOM}`} />
                         <Flex className="px-4 text-center items-center">
                             <p className="inline-block">

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -9,6 +9,7 @@ export default {
         const staticPaths = [
             '/',
             '/about',
+            '/contact',
             '/design-technologist',
             '/resume',
             '/services',


### PR DESCRIPTION
## Summary

Per the ticket feedback (visibility > bot-protection, and "make doubly sure we are funneling users to a contact form"), this makes Seth reachable. Previously **no email appeared anywhere** on the site and the only form was the paid-`/services` inquiry funnel.

- **New `/contact` page** — visible email, social links, a book-a-call link, and a general-purpose message form. Reuses the existing Airtable + `validateContactForm` pattern with a hidden `offer="general-contact"` so these records are distinguishable from service leads.
- **Email visible sitewide** — `sethdavis512@gmail.com` now shows in the footer (with GitHub/LinkedIn/X links) on every page.
- **Resume** — visible email + "Send me a message" link near the top, where recruiters land.
- **About** — "Get in touch" CTA repointed to `/contact`, with the email shown inline.
- **Discoverability** — `Contact` added to the header nav and the Cmd+K command palette.
- Route registered and added to the prerender list.

Email address to publish was confirmed with Seth before implementing.

Fixes TEC-188

## Visuals

Screenshots are attached to the Linear issue ([TEC-188](https://linear.app/tech-with-seth/issue/TEC-188/update-ways-to-contact-me)): contact page (desktop + mobile), footer, resume, and about CTA. Cloudinary upload wasn't available (no API secret on this machine), so they're hosted on the ticket rather than embedded here.

Local copies (drag into this description to embed inline if desired):
- `~/Documents/screenshots/tec-188/01-contact-default-desktop.png`
- `~/Documents/screenshots/tec-188/03-contact-mobile.png`
- `~/Documents/screenshots/tec-188/04-footer-desktop.png`
- `~/Documents/screenshots/tec-188/05-resume-top-desktop.png`
- `~/Documents/screenshots/tec-188/06-about-cta-desktop.png`

## Testing

- `bun run typecheck` — passes
- `bun run build` — passes; `/contact` prerenders cleanly, no nested-`<p>` hydration issues
- Manual: verified `/contact`, footer, `/resume`, `/about` render; form validation fires (native email + required); did **not** submit a live record to Airtable

## Notes for review

- The message form posts to the same Airtable `Customers` table as the services form, tagged `Offer=general-contact`. No schema changes.
- `/services` paid-inquiry funnel is left intact; the "Reach out" CTA on work pages still points there.