### PR TITLE
Warm studio minimal redesign + Services reposition

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "dev", "--", "--port", "5199", "--strictPort"],
+      "port": 5199,
+      "autoPort": false
+    }
+  ]
+}

--- a/app/app.css
+++ b/app/app.css
@@ -2,40 +2,74 @@
 @plugin '@tailwindcss/typography';
 
 @theme {
+    /* Editorial brutalist type stack */
     --font-sans:
-        'Inter', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+        'Archivo', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
         'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
-    --color-primary-100: oklch(0.96 0.03 28);
-    --color-primary-200: oklch(0.90 0.06 28);
-    --color-primary-300: oklch(0.82 0.11 28);
-    --color-primary-400: oklch(0.74 0.15 28);
-    --color-primary-500: oklch(0.66 0.17 28);
-    --color-primary-600: oklch(0.57 0.18 28);
-    --color-primary-700: oklch(0.47 0.15 28);
-    --color-primary-800: oklch(0.40 0.11 28);
-    --color-primary-900: oklch(0.33 0.08 28);
+    --font-display: 'Fraunces', 'Iowan Old Style', 'Georgia', ui-serif, serif;
+    --font-mono:
+        'JetBrains Mono', ui-monospace, 'SFMono-Regular', 'Menlo', monospace;
 
-    --color-secondary-100: oklch(0.95 0.01 230);
-    --color-secondary-200: oklch(0.88 0.03 230);
-    --color-secondary-300: oklch(0.80 0.04 230);
-    --color-secondary-400: oklch(0.72 0.06 230);
-    --color-secondary-500: oklch(0.64 0.06 230);
-    --color-secondary-600: oklch(0.54 0.05 230);
-    --color-secondary-700: oklch(0.46 0.04 230);
-    --color-secondary-800: oklch(0.40 0.03 230);
-    --color-secondary-900: oklch(0.34 0.02 230);
+    /* Acid chartreuse — the highlighter on newsprint */
+    --color-primary-100: oklch(0.97 0.06 125);
+    --color-primary-200: oklch(0.94 0.12 125);
+    --color-primary-300: oklch(0.9 0.17 125);
+    --color-primary-400: oklch(0.86 0.21 125);
+    --color-primary-500: oklch(0.81 0.22 125);
+    --color-primary-600: oklch(0.68 0.18 126);
+    --color-primary-700: oklch(0.55 0.14 127);
+    --color-primary-800: oklch(0.45 0.11 128);
+    --color-primary-900: oklch(0.37 0.08 128);
 
-    --color-tertiary-100: oklch(0.96 0.03 60);
-    --color-tertiary-200: oklch(0.91 0.06 60);
-    --color-tertiary-300: oklch(0.84 0.10 60);
-    --color-tertiary-400: oklch(0.77 0.12 60);
-    --color-tertiary-500: oklch(0.68 0.12 60);
-    --color-tertiary-600: oklch(0.58 0.10 60);
-    --color-tertiary-700: oklch(0.48 0.08 60);
-    --color-tertiary-800: oklch(0.40 0.06 60);
-    --color-tertiary-900: oklch(0.34 0.04 60);
+    /* Slate blue — cool editorial support */
+    --color-secondary-100: oklch(0.95 0.02 250);
+    --color-secondary-200: oklch(0.88 0.04 250);
+    --color-secondary-300: oklch(0.8 0.06 250);
+    --color-secondary-400: oklch(0.72 0.08 250);
+    --color-secondary-500: oklch(0.64 0.09 250);
+    --color-secondary-600: oklch(0.54 0.08 250);
+    --color-secondary-700: oklch(0.46 0.06 250);
+    --color-secondary-800: oklch(0.4 0.05 250);
+    --color-secondary-900: oklch(0.34 0.04 250);
 
-    --prose-invert-body: #ffffff;
+    /* Vermillion — rare, loud emphasis */
+    --color-tertiary-100: oklch(0.95 0.04 32);
+    --color-tertiary-200: oklch(0.89 0.08 32);
+    --color-tertiary-300: oklch(0.8 0.14 32);
+    --color-tertiary-400: oklch(0.7 0.19 32);
+    --color-tertiary-500: oklch(0.62 0.21 32);
+    --color-tertiary-600: oklch(0.54 0.19 32);
+    --color-tertiary-700: oklch(0.46 0.16 32);
+    --color-tertiary-800: oklch(0.39 0.12 32);
+    --color-tertiary-900: oklch(0.33 0.09 32);
+
+    /* Warm ink-and-bone neutrals (overrides Tailwind zinc) */
+    --color-zinc-50: oklch(0.975 0.005 85);
+    --color-zinc-100: oklch(0.955 0.007 85);
+    --color-zinc-200: oklch(0.91 0.008 85);
+    --color-zinc-300: oklch(0.86 0.008 85);
+    --color-zinc-400: oklch(0.7 0.01 85);
+    --color-zinc-500: oklch(0.55 0.01 85);
+    --color-zinc-600: oklch(0.44 0.01 85);
+    --color-zinc-700: oklch(0.37 0.01 85);
+    --color-zinc-800: oklch(0.27 0.008 85);
+    --color-zinc-900: oklch(0.215 0.007 85);
+    --color-zinc-950: oklch(0.155 0.006 85);
+
+    --color-white: oklch(0.965 0.008 90);
+    --color-black: oklch(0.13 0.005 85);
+
+    /* Brutalist geometry: no soft corners */
+    --radius-xs: 0;
+    --radius-sm: 0;
+    --radius-md: 0;
+    --radius-lg: 0;
+    --radius-xl: 0;
+    --radius-2xl: 0;
+    --radius-3xl: 0;
+    --radius-4xl: 0;
+
+    --prose-invert-body: oklch(0.93 0.008 88);
 
     --animate-fade-slide: fade-slide 0.75s ease-out 0.3s forwards;
     --animate-pulse-subtle: pulse-subtle 3s ease-in-out infinite;
@@ -81,11 +115,23 @@
 
 html,
 body {
-    @apply bg-white dark:bg-zinc-950;
+    @apply bg-white text-black dark:bg-zinc-950 dark:text-zinc-100;
 
     @media (prefers-color-scheme: dark) {
         color-scheme: dark;
     }
+}
+
+/* Highlighter selection — acid on ink */
+::selection {
+    background: var(--color-primary-400);
+    color: var(--color-black);
+}
+
+/* Display serif renders best with optical sizing + tight tracking */
+.font-display {
+    font-optical-sizing: auto;
+    letter-spacing: -0.02em;
 }
 
 

--- a/app/app.css
+++ b/app/app.css
@@ -10,38 +10,38 @@
     --font-mono:
         'JetBrains Mono', ui-monospace, 'SFMono-Regular', 'Menlo', monospace;
 
-    /* Acid chartreuse — the highlighter on newsprint */
-    --color-primary-100: oklch(0.97 0.06 125);
-    --color-primary-200: oklch(0.94 0.12 125);
-    --color-primary-300: oklch(0.9 0.17 125);
-    --color-primary-400: oklch(0.86 0.21 125);
-    --color-primary-500: oklch(0.81 0.22 125);
-    --color-primary-600: oklch(0.68 0.18 126);
-    --color-primary-700: oklch(0.55 0.14 127);
-    --color-primary-800: oklch(0.45 0.11 128);
-    --color-primary-900: oklch(0.37 0.08 128);
+    /* Muted amber — a single warm accent, low volume */
+    --color-primary-100: oklch(0.96 0.04 72);
+    --color-primary-200: oklch(0.92 0.07 72);
+    --color-primary-300: oklch(0.86 0.1 72);
+    --color-primary-400: oklch(0.79 0.12 72);
+    --color-primary-500: oklch(0.72 0.13 72);
+    --color-primary-600: oklch(0.62 0.12 72);
+    --color-primary-700: oklch(0.52 0.1 72);
+    --color-primary-800: oklch(0.43 0.08 73);
+    --color-primary-900: oklch(0.36 0.06 74);
 
-    /* Slate blue — cool editorial support */
-    --color-secondary-100: oklch(0.95 0.02 250);
-    --color-secondary-200: oklch(0.88 0.04 250);
-    --color-secondary-300: oklch(0.8 0.06 250);
-    --color-secondary-400: oklch(0.72 0.08 250);
-    --color-secondary-500: oklch(0.64 0.09 250);
-    --color-secondary-600: oklch(0.54 0.08 250);
-    --color-secondary-700: oklch(0.46 0.06 250);
-    --color-secondary-800: oklch(0.4 0.05 250);
-    --color-secondary-900: oklch(0.34 0.04 250);
+    /* Sage — quiet green support */
+    --color-secondary-100: oklch(0.95 0.02 150);
+    --color-secondary-200: oklch(0.89 0.04 150);
+    --color-secondary-300: oklch(0.81 0.06 150);
+    --color-secondary-400: oklch(0.73 0.07 150);
+    --color-secondary-500: oklch(0.65 0.08 150);
+    --color-secondary-600: oklch(0.55 0.07 150);
+    --color-secondary-700: oklch(0.46 0.06 150);
+    --color-secondary-800: oklch(0.39 0.05 150);
+    --color-secondary-900: oklch(0.33 0.04 150);
 
-    /* Vermillion — rare, loud emphasis */
-    --color-tertiary-100: oklch(0.95 0.04 32);
-    --color-tertiary-200: oklch(0.89 0.08 32);
-    --color-tertiary-300: oklch(0.8 0.14 32);
-    --color-tertiary-400: oklch(0.7 0.19 32);
-    --color-tertiary-500: oklch(0.62 0.21 32);
-    --color-tertiary-600: oklch(0.54 0.19 32);
-    --color-tertiary-700: oklch(0.46 0.16 32);
-    --color-tertiary-800: oklch(0.39 0.12 32);
-    --color-tertiary-900: oklch(0.33 0.09 32);
+    /* Clay — soft warm emphasis (errors, alerts) */
+    --color-tertiary-100: oklch(0.95 0.03 35);
+    --color-tertiary-200: oklch(0.89 0.06 35);
+    --color-tertiary-300: oklch(0.8 0.1 35);
+    --color-tertiary-400: oklch(0.71 0.13 35);
+    --color-tertiary-500: oklch(0.63 0.14 35);
+    --color-tertiary-600: oklch(0.55 0.13 35);
+    --color-tertiary-700: oklch(0.47 0.11 35);
+    --color-tertiary-800: oklch(0.4 0.09 35);
+    --color-tertiary-900: oklch(0.34 0.07 35);
 
     /* Warm ink-and-bone neutrals (overrides Tailwind zinc) */
     --color-zinc-50: oklch(0.975 0.005 85);
@@ -58,16 +58,6 @@
 
     --color-white: oklch(0.965 0.008 90);
     --color-black: oklch(0.13 0.005 85);
-
-    /* Brutalist geometry: no soft corners */
-    --radius-xs: 0;
-    --radius-sm: 0;
-    --radius-md: 0;
-    --radius-lg: 0;
-    --radius-xl: 0;
-    --radius-2xl: 0;
-    --radius-3xl: 0;
-    --radius-4xl: 0;
 
     --prose-invert-body: oklch(0.93 0.008 88);
 
@@ -122,9 +112,9 @@ body {
     }
 }
 
-/* Highlighter selection — acid on ink */
+/* Selection — warm amber wash */
 ::selection {
-    background: var(--color-primary-400);
+    background: var(--color-primary-300);
     color: var(--color-black);
 }
 

--- a/app/components/Banner.tsx
+++ b/app/components/Banner.tsx
@@ -5,7 +5,7 @@ import { Card } from './Card';
 import type { VariantProps } from 'cva';
 
 export const bannerVariants = cva({
-    base: 'p-4 border-2 border-black dark:border-zinc-200',
+    base: 'p-4 border border-zinc-200 dark:border-zinc-800',
     variants: {
         variant: {
             primary: 'bg-primary-400/30 dark:bg-primary-400/15',

--- a/app/components/Banner.tsx
+++ b/app/components/Banner.tsx
@@ -5,15 +5,12 @@ import { Card } from './Card';
 import type { VariantProps } from 'cva';
 
 export const bannerVariants = cva({
-    base: 'p-4',
+    base: 'p-4 border-2 border-black dark:border-zinc-200',
     variants: {
         variant: {
-            primary:
-                'dark:bg-primary-700/35 dark:border-primary-500 bg-primary-400/35 border-primary-500',
-            secondary:
-                'dark:bg-secondary-700/35 dark:border-secondary-500 bg-secondary-400/35 border-secondary-500',
-            tertiary:
-                'dark:bg-tertiary-700/35 dark:border-tertiary-500 bg-tertiary-400/35 border-tertiary-500'
+            primary: 'bg-primary-400/30 dark:bg-primary-400/15',
+            secondary: 'bg-secondary-400/25 dark:bg-secondary-500/15',
+            tertiary: 'bg-tertiary-400/25 dark:bg-tertiary-500/15'
         }
     },
     defaultVariants: {

--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -6,7 +6,13 @@ import { Link } from 'react-router';
 import { cva, cx } from '~/cva.config';
 
 export const buttonVariants = cva({
-    base: 'inline-flex items-center justify-center rounded-lg font-medium transition-colors duration-200 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+    base: [
+        'inline-flex items-center justify-center cursor-pointer select-none',
+        'font-mono uppercase tracking-[0.15em] font-semibold',
+        'border-2 transition-[background-color,color,transform,box-shadow] duration-150',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+        'focus-visible:ring-primary-500 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950'
+    ],
     variants: {
         color: {
             primary: [],
@@ -17,15 +23,14 @@ export const buttonVariants = cva({
             soft: [],
             outline: [],
             ghost: [
-                'border-none bg-transparent text-current',
-                'hover:bg-zinc-800',
-                'focus-visible:ring-primary-400'
+                'border-transparent bg-transparent text-current',
+                'hover:bg-zinc-200 dark:hover:bg-zinc-800'
             ]
         },
         size: {
-            sm: 'px-3 py-1.5 text-sm gap-1.5',
-            md: 'px-4 py-2 text-sm gap-1.5',
-            lg: 'px-6 py-3 text-base gap-2'
+            sm: 'px-3 py-1.5 text-xs gap-1.5',
+            md: 'px-5 py-2.5 text-xs gap-2',
+            lg: 'px-7 py-3.5 text-sm gap-2.5'
         }
     },
     defaultVariants: {
@@ -34,53 +39,55 @@ export const buttonVariants = cva({
         size: 'md'
     },
     compoundVariants: [
-        // Primary solid
+        // Primary solid: acid slab with hard offset shadow that collapses on press
         {
             color: 'primary',
             variant: 'solid',
             className: [
-                'bg-primary-600 hover:bg-primary-500 text-white',
-                'border-none shadow-sm shadow-primary-900/30',
-                'focus-visible:ring-primary-400'
+                'bg-primary-400 text-black border-black dark:border-white',
+                'shadow-[4px_4px_0_0_var(--color-black)] dark:shadow-[4px_4px_0_0_var(--color-white)]',
+                'hover:translate-x-[2px] hover:translate-y-[2px]',
+                'hover:shadow-[2px_2px_0_0_var(--color-black)] dark:hover:shadow-[2px_2px_0_0_var(--color-white)]',
+                'active:translate-x-[4px] active:translate-y-[4px] active:shadow-none'
             ]
         },
-        // Primary outline
+        // Primary outline: ink frame, inverts to acid on hover
         {
             color: 'primary',
             variant: 'outline',
             className: [
-                'border border-primary-500/50 hover:border-primary-400 text-primary-400 hover:text-primary-300',
-                'bg-transparent hover:bg-primary-500/10',
-                'focus-visible:ring-primary-400'
+                'bg-transparent text-black border-black dark:text-white dark:border-white',
+                'hover:bg-primary-400 hover:text-black dark:hover:text-black dark:hover:border-primary-400'
             ]
         },
-        // Primary soft
+        // Primary soft: quiet acid wash
         {
             color: 'primary',
             variant: 'soft',
             className: [
-                'border-none bg-primary-500/15 hover:bg-primary-500/25 text-primary-400 hover:text-primary-300',
-                'focus-visible:ring-primary-400'
+                'border-transparent bg-primary-400/20 text-primary-800 dark:text-primary-300',
+                'hover:bg-primary-400/35'
             ]
         },
-        // Secondary solid
+        // Secondary solid: bone slab
         {
             color: 'secondary',
             variant: 'solid',
             className: [
-                'bg-secondary-600 hover:bg-secondary-500 text-white',
-                'border-none shadow-sm shadow-secondary-900/30',
-                'focus-visible:ring-secondary-400'
+                'bg-white text-black border-black dark:border-white',
+                'shadow-[4px_4px_0_0_var(--color-black)] dark:shadow-[4px_4px_0_0_var(--color-white)]',
+                'hover:translate-x-[2px] hover:translate-y-[2px]',
+                'hover:shadow-[2px_2px_0_0_var(--color-black)] dark:hover:shadow-[2px_2px_0_0_var(--color-white)]',
+                'active:translate-x-[4px] active:translate-y-[4px] active:shadow-none'
             ]
         },
-        // Secondary outline
+        // Secondary outline: slate frame
         {
             color: 'secondary',
             variant: 'outline',
             className: [
-                'border border-secondary-500/50 hover:border-secondary-400 text-secondary-400 hover:text-secondary-300',
-                'bg-transparent hover:bg-secondary-500/10',
-                'focus-visible:ring-secondary-400'
+                'bg-transparent text-secondary-700 border-secondary-700 dark:text-secondary-300 dark:border-secondary-400',
+                'hover:bg-secondary-400 hover:text-black dark:hover:text-black'
             ]
         },
         // Secondary soft
@@ -88,8 +95,8 @@ export const buttonVariants = cva({
             color: 'secondary',
             variant: 'soft',
             className: [
-                'border-none bg-secondary-500/15 hover:bg-secondary-500/25 text-secondary-400 hover:text-secondary-300',
-                'focus-visible:ring-secondary-400'
+                'border-transparent bg-secondary-500/15 text-secondary-700 dark:text-secondary-300',
+                'hover:bg-secondary-500/30'
             ]
         }
     ]

--- a/app/components/Button.tsx
+++ b/app/components/Button.tsx
@@ -8,8 +8,8 @@ import { cva, cx } from '~/cva.config';
 export const buttonVariants = cva({
     base: [
         'inline-flex items-center justify-center cursor-pointer select-none',
-        'font-mono uppercase tracking-[0.15em] font-semibold',
-        'border-2 transition-[background-color,color,transform,box-shadow] duration-150',
+        'font-medium rounded-lg',
+        'border transition-colors duration-200',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
         'focus-visible:ring-primary-500 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950'
     ],
@@ -24,13 +24,13 @@ export const buttonVariants = cva({
             outline: [],
             ghost: [
                 'border-transparent bg-transparent text-current',
-                'hover:bg-zinc-200 dark:hover:bg-zinc-800'
+                'hover:bg-zinc-100 dark:hover:bg-zinc-800/70'
             ]
         },
         size: {
-            sm: 'px-3 py-1.5 text-xs gap-1.5',
-            md: 'px-5 py-2.5 text-xs gap-2',
-            lg: 'px-7 py-3.5 text-sm gap-2.5'
+            sm: 'px-3 py-1.5 text-sm gap-1.5',
+            md: 'px-4 py-2 text-sm gap-2',
+            lg: 'px-6 py-3 text-base gap-2.5'
         }
     },
     defaultVariants: {
@@ -39,55 +39,51 @@ export const buttonVariants = cva({
         size: 'md'
     },
     compoundVariants: [
-        // Primary solid: acid slab with hard offset shadow that collapses on press
+        // Primary solid: warm amber, ink text for contrast
         {
             color: 'primary',
             variant: 'solid',
             className: [
-                'bg-primary-400 text-black border-black dark:border-white',
-                'shadow-[4px_4px_0_0_var(--color-black)] dark:shadow-[4px_4px_0_0_var(--color-white)]',
-                'hover:translate-x-[2px] hover:translate-y-[2px]',
-                'hover:shadow-[2px_2px_0_0_var(--color-black)] dark:hover:shadow-[2px_2px_0_0_var(--color-white)]',
-                'active:translate-x-[4px] active:translate-y-[4px] active:shadow-none'
+                'bg-primary-400 hover:bg-primary-300 text-black border-transparent',
+                'shadow-sm'
             ]
         },
-        // Primary outline: ink frame, inverts to acid on hover
+        // Primary outline: quiet frame, amber on hover
         {
             color: 'primary',
             variant: 'outline',
             className: [
-                'bg-transparent text-black border-black dark:text-white dark:border-white',
-                'hover:bg-primary-400 hover:text-black dark:hover:text-black dark:hover:border-primary-400'
+                'bg-transparent text-zinc-800 dark:text-zinc-200',
+                'border-zinc-300 dark:border-zinc-700',
+                'hover:border-primary-500/60 hover:text-primary-700 dark:hover:text-primary-300'
             ]
         },
-        // Primary soft: quiet acid wash
+        // Primary soft: amber wash
         {
             color: 'primary',
             variant: 'soft',
             className: [
-                'border-transparent bg-primary-400/20 text-primary-800 dark:text-primary-300',
-                'hover:bg-primary-400/35'
+                'border-transparent bg-primary-500/15 text-primary-800 dark:text-primary-300',
+                'hover:bg-primary-500/25'
             ]
         },
-        // Secondary solid: bone slab
+        // Secondary solid: sage
         {
             color: 'secondary',
             variant: 'solid',
             className: [
-                'bg-white text-black border-black dark:border-white',
-                'shadow-[4px_4px_0_0_var(--color-black)] dark:shadow-[4px_4px_0_0_var(--color-white)]',
-                'hover:translate-x-[2px] hover:translate-y-[2px]',
-                'hover:shadow-[2px_2px_0_0_var(--color-black)] dark:hover:shadow-[2px_2px_0_0_var(--color-white)]',
-                'active:translate-x-[4px] active:translate-y-[4px] active:shadow-none'
+                'bg-secondary-500 hover:bg-secondary-400 text-black border-transparent',
+                'shadow-sm'
             ]
         },
-        // Secondary outline: slate frame
+        // Secondary outline
         {
             color: 'secondary',
             variant: 'outline',
             className: [
-                'bg-transparent text-secondary-700 border-secondary-700 dark:text-secondary-300 dark:border-secondary-400',
-                'hover:bg-secondary-400 hover:text-black dark:hover:text-black'
+                'bg-transparent text-secondary-700 dark:text-secondary-300',
+                'border-zinc-300 dark:border-zinc-700',
+                'hover:border-secondary-500/60'
             ]
         },
         // Secondary soft
@@ -96,7 +92,7 @@ export const buttonVariants = cva({
             variant: 'soft',
             className: [
                 'border-transparent bg-secondary-500/15 text-secondary-700 dark:text-secondary-300',
-                'hover:bg-secondary-500/30'
+                'hover:bg-secondary-500/25'
             ]
         }
     ]

--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -13,7 +13,7 @@ export function Card({
     return (
         <div
             className={cx(
-                'p-4 rounded-lg bg-zinc-100 dark:bg-zinc-900',
+                'p-4 border-2 border-black bg-white dark:border-zinc-200 dark:bg-zinc-900',
                 className
             )}
             {...rest}

--- a/app/components/Card.tsx
+++ b/app/components/Card.tsx
@@ -13,7 +13,7 @@ export function Card({
     return (
         <div
             className={cx(
-                'p-4 border-2 border-black bg-white dark:border-zinc-200 dark:bg-zinc-900',
+                'p-4 rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900',
                 className
             )}
             {...rest}

--- a/app/components/CodeBlock.tsx
+++ b/app/components/CodeBlock.tsx
@@ -61,8 +61,8 @@ export function CodeBlock({
                 const html = await codeToHtml(code, {
                     lang: normalizedLang,
                     themes: {
-                        light: 'github-dark',
-                        dark: 'github-light'
+                        light: 'github-light',
+                        dark: 'github-dark'
                     },
                     transformers: [
                         {
@@ -105,26 +105,19 @@ export function CodeBlock({
                     className
                 )}
             >
-                <div className="flex items-center justify-between border-b border-zinc-200/60 dark:border-zinc-700/40 px-6 py-4">
-                    <div className="flex items-center gap-3">
-                        <div className="flex gap-1.5">
-                            <div className="w-3 h-3 rounded-full bg-red-400/80"></div>
-                            <div className="w-3 h-3 rounded-full bg-yellow-400/80"></div>
-                            <div className="w-3 h-3 rounded-full bg-green-400/80"></div>
-                        </div>
-                        <span className="text-xs font-mono font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider px-2 py-1 rounded bg-zinc-100/80 dark:bg-zinc-800/60">
-                            {language}
-                        </span>
-                    </div>
+                <div className="flex items-center justify-between border-b-2 border-black dark:border-zinc-200 px-4 py-2">
+                    <span className="text-xs font-mono font-semibold text-zinc-600 dark:text-zinc-300 uppercase tracking-[0.2em]">
+                        {language}
+                    </span>
                     <button
                         onClick={copyToClipboard}
-                        className="opacity-0 group-hover:opacity-100 transition-all duration-200 text-xs font-mono font-medium text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200 px-3 py-1.5 rounded-md bg-zinc-100/80 hover:bg-zinc-200/80 dark:bg-zinc-800/60 dark:hover:bg-zinc-700/60 border border-zinc-200/60 dark:border-zinc-600/40"
+                        className="text-xs font-mono font-semibold uppercase tracking-[0.15em] cursor-pointer px-3 py-1 border-2 border-black dark:border-zinc-200 text-black dark:text-white hover:bg-primary-400 hover:text-black dark:hover:text-black transition-colors duration-150"
                         title="Copy to clipboard"
                     >
-                        {copied ? 'COPIED' : 'COPY'}
+                        {copied ? 'Copied' : 'Copy'}
                     </button>
                 </div>
-                <div className="overflow-x-auto bg-gradient-to-br from-zinc-50/30 to-white/50 dark:from-zinc-900/40 dark:to-zinc-800/30">
+                <div className="overflow-x-auto p-4">
                     <pre className="text-[14px] leading-7 text-zinc-800 dark:text-zinc-100 overflow-x-auto font-mono bg-transparent border-0 m-0">
                         <code>{code}</code>
                     </pre>
@@ -137,39 +130,28 @@ export function CodeBlock({
         <div
             className={cx(
                 'not-prose group relative overflow-hidden',
-                'rounded-xl border border-zinc-200/80 dark:border-zinc-700/50',
-                'bg-gradient-to-br from-zinc-50 via-white to-zinc-50/50',
-                'dark:from-zinc-900/90 dark:via-zinc-900 dark:to-zinc-800/90',
-                'shadow-2xl shadow-zinc-900/5 dark:shadow-zinc-900/20',
-                'ring-1 ring-zinc-900/5 dark:ring-white/10',
-                'backdrop-blur-sm',
+                'border-2 border-black dark:border-zinc-200',
+                'bg-zinc-50 dark:bg-zinc-900',
                 className
             )}
         >
-            <div className="flex items-center justify-between border-b border-zinc-200/60 dark:border-zinc-700/40 px-6 py-4">
-                <div className="flex items-center gap-3">
-                    <div className="flex gap-1.5">
-                        <div className="w-3 h-3 rounded-full bg-red-400/80"></div>
-                        <div className="w-3 h-3 rounded-full bg-yellow-400/80"></div>
-                        <div className="w-3 h-3 rounded-full bg-green-400/80"></div>
-                    </div>
-                    <span className="text-xs font-mono font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider px-2 py-1 rounded bg-zinc-100/80 dark:bg-zinc-800/60">
-                        {language}
-                    </span>
-                </div>
+            <div className="flex items-center justify-between border-b-2 border-black dark:border-zinc-200 px-4 py-2">
+                <span className="text-xs font-mono font-semibold text-zinc-600 dark:text-zinc-300 uppercase tracking-[0.2em]">
+                    {language}
+                </span>
                 <button
                     onClick={copyToClipboard}
-                    className="opacity-0 group-hover:opacity-100 transition-all duration-200 text-xs font-mono font-medium text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200 px-3 py-1.5 rounded-md bg-zinc-100/80 hover:bg-zinc-200/80 dark:bg-zinc-800/60 dark:hover:bg-zinc-700/60 border border-zinc-200/60 dark:border-zinc-600/40"
+                    className="text-xs font-mono font-semibold uppercase tracking-[0.15em] cursor-pointer px-3 py-1 border-2 border-black dark:border-zinc-200 text-black dark:text-white hover:bg-primary-400 hover:text-black dark:hover:text-black transition-colors duration-150"
                     title="Copy to clipboard"
                 >
-                    {copied ? 'COPIED' : 'COPY'}
+                    {copied ? 'Copied' : 'Copy'}
                 </button>
             </div>
             <div
                 className={cx(
-                    'overflow-x-auto bg-gradient-to-br from-zinc-50/30 to-white/50 dark:from-zinc-900/40 dark:to-zinc-800/30 p-4',
+                    'overflow-x-auto p-4',
                     '[&>pre]:!m-0 [&>pre]:!border-0 [&>pre]:!bg-transparent',
-                    '[&>pre]:!px-6 [&>pre]:!py-8 [&>pre]:!font-mono [&>pre]:!text-[14px] [&>pre]:!leading-7',
+                    '[&>pre]:!p-0 [&>pre]:!font-mono [&>pre]:!text-[14px] [&>pre]:!leading-7',
                     '[&>pre]:!text-zinc-800 [&>pre]:dark:!text-zinc-100',
                     '[&_code]:!font-mono [&_code]:!text-[14px] [&_code]:!leading-7'
                 )}

--- a/app/components/CodeBlock.tsx
+++ b/app/components/CodeBlock.tsx
@@ -105,13 +105,13 @@ export function CodeBlock({
                     className
                 )}
             >
-                <div className="flex items-center justify-between border-b-2 border-black dark:border-zinc-200 px-4 py-2">
-                    <span className="text-xs font-mono font-semibold text-zinc-600 dark:text-zinc-300 uppercase tracking-[0.2em]">
+                <div className="flex items-center justify-between border-b border-zinc-200 dark:border-zinc-800 px-4 py-2">
+                    <span className="text-xs font-mono text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
                         {language}
                     </span>
                     <button
                         onClick={copyToClipboard}
-                        className="text-xs font-mono font-semibold uppercase tracking-[0.15em] cursor-pointer px-3 py-1 border-2 border-black dark:border-zinc-200 text-black dark:text-white hover:bg-primary-400 hover:text-black dark:hover:text-black transition-colors duration-150"
+                        className="text-xs font-medium cursor-pointer px-3 py-1 rounded-md border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-300 hover:text-primary-700 dark:hover:text-primary-300 hover:border-primary-500/60 transition-colors duration-150"
                         title="Copy to clipboard"
                     >
                         {copied ? 'Copied' : 'Copy'}
@@ -130,18 +130,18 @@ export function CodeBlock({
         <div
             className={cx(
                 'not-prose group relative overflow-hidden',
-                'border-2 border-black dark:border-zinc-200',
+                'border border-zinc-200 dark:border-zinc-800',
                 'bg-zinc-50 dark:bg-zinc-900',
                 className
             )}
         >
-            <div className="flex items-center justify-between border-b-2 border-black dark:border-zinc-200 px-4 py-2">
-                <span className="text-xs font-mono font-semibold text-zinc-600 dark:text-zinc-300 uppercase tracking-[0.2em]">
+            <div className="flex items-center justify-between border-b border-zinc-200 dark:border-zinc-800 px-4 py-2">
+                <span className="text-xs font-mono text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
                     {language}
                 </span>
                 <button
                     onClick={copyToClipboard}
-                    className="text-xs font-mono font-semibold uppercase tracking-[0.15em] cursor-pointer px-3 py-1 border-2 border-black dark:border-zinc-200 text-black dark:text-white hover:bg-primary-400 hover:text-black dark:hover:text-black transition-colors duration-150"
+                    className="text-xs font-medium cursor-pointer px-3 py-1 rounded-md border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-300 hover:text-primary-700 dark:hover:text-primary-300 hover:border-primary-500/60 transition-colors duration-150"
                     title="Copy to clipboard"
                 >
                     {copied ? 'Copied' : 'Copy'}

--- a/app/components/CommandPalette.tsx
+++ b/app/components/CommandPalette.tsx
@@ -111,20 +111,18 @@ function CommandSection({ title, links, onSelect }: CommandSectionProps) {
     return (
         <Command.Group
             heading={title}
-            className="p-6 **:[[cmdk-group-heading]]:text-zinc-700 dark:**:[[cmdk-group-heading]]:text-zinc-300 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:mb-4"
+            className="p-6 **:[[cmdk-group-heading]]:font-mono **:[[cmdk-group-heading]]:uppercase **:[[cmdk-group-heading]]:tracking-[0.2em] **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:text-zinc-500 dark:**:[[cmdk-group-heading]]:text-zinc-400 **:[[cmdk-group-heading]]:mb-4"
         >
             {links.map((link) => (
                 <Command.Item
                     key={link.to}
                     value={link.label}
                     onSelect={() => onSelect(link.to)}
-                    className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-700 data-[selected=true]:bg-zinc-100 dark:data-[selected=true]:bg-zinc-700 cursor-pointer group"
+                    className="flex items-center gap-3 px-3 py-2 hover:bg-primary-400 hover:text-black data-[selected=true]:bg-primary-400 data-[selected=true]:**:text-black cursor-pointer group"
                 >
-                    <div className="flex items-center gap-3 flex-1">
-                        <link.icon className="w-4 h-4 text-zinc-500 dark:text-zinc-400" />
-                        <span className="text-zinc-700 dark:text-zinc-300">
-                            {link.label}
-                        </span>
+                    <div className="flex items-center gap-3 flex-1 text-zinc-700 dark:text-zinc-300 group-hover:text-black group-data-[selected=true]:text-black">
+                        <link.icon className="w-4 h-4 text-current" />
+                        <span className="text-current">{link.label}</span>
                     </div>
                 </Command.Item>
             ))}
@@ -163,20 +161,20 @@ export function CommandPalette({
                 className="fixed inset-0 bg-black/50"
                 onClick={() => onOpenChange(false)}
             />
-            <div className="relative bg-white dark:bg-zinc-800 rounded-2xl border border-zinc-200 dark:border-zinc-700 w-full max-w-2xl mx-4 overflow-hidden shadow-2xl">
+            <div className="relative bg-white dark:bg-zinc-950 border-2 border-black dark:border-zinc-200 w-full max-w-2xl mx-4 overflow-hidden shadow-[8px_8px_0_0_var(--color-black)] dark:shadow-[8px_8px_0_0_var(--color-zinc-200)]">
                 {/* Navigation Header */}
-                <div className="flex items-center gap-3 px-6 py-4 border-b border-zinc-200 dark:border-zinc-700">
+                <div className="flex items-center gap-3 px-6 py-4 border-b-2 border-black dark:border-zinc-200">
                     <Home className="w-4 h-4 text-zinc-500 dark:text-zinc-400" />
-                    <span className="text-zinc-700 dark:text-zinc-300 text-sm font-medium">
-                        Home
+                    <span className="font-mono uppercase tracking-[0.2em] text-xs text-zinc-700 dark:text-zinc-300">
+                        Index
                     </span>
                 </div>
 
                 {/* Main Search Input */}
-                <div className="p-6 border-b border-zinc-200 dark:border-zinc-700">
+                <div className="p-6 border-b-2 border-black dark:border-zinc-200">
                     <Command.Input
                         placeholder="Where would you like to go?"
-                        className="w-full bg-transparent text-zinc-900 dark:text-zinc-100 text-xl font-medium placeholder-zinc-400 dark:placeholder-zinc-500 border-none outline-none"
+                        className="w-full bg-transparent text-black dark:text-zinc-100 text-xl font-display font-semibold placeholder-zinc-400 dark:placeholder-zinc-500 border-none outline-none"
                     />
                 </div>
 

--- a/app/components/CommandPalette.tsx
+++ b/app/components/CommandPalette.tsx
@@ -111,16 +111,16 @@ function CommandSection({ title, links, onSelect }: CommandSectionProps) {
     return (
         <Command.Group
             heading={title}
-            className="p-6 **:[[cmdk-group-heading]]:font-mono **:[[cmdk-group-heading]]:uppercase **:[[cmdk-group-heading]]:tracking-[0.2em] **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:text-zinc-500 dark:**:[[cmdk-group-heading]]:text-zinc-400 **:[[cmdk-group-heading]]:mb-4"
+            className="p-6 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:tracking-wide **:[[cmdk-group-heading]]:text-zinc-500 dark:**:[[cmdk-group-heading]]:text-zinc-400 **:[[cmdk-group-heading]]:mb-4"
         >
             {links.map((link) => (
                 <Command.Item
                     key={link.to}
                     value={link.label}
                     onSelect={() => onSelect(link.to)}
-                    className="flex items-center gap-3 px-3 py-2 hover:bg-primary-400 hover:text-black data-[selected=true]:bg-primary-400 data-[selected=true]:**:text-black cursor-pointer group"
+                    className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 data-[selected=true]:bg-zinc-100 dark:data-[selected=true]:bg-zinc-800 cursor-pointer group"
                 >
-                    <div className="flex items-center gap-3 flex-1 text-zinc-700 dark:text-zinc-300 group-hover:text-black group-data-[selected=true]:text-black">
+                    <div className="flex items-center gap-3 flex-1 text-zinc-700 dark:text-zinc-300">
                         <link.icon className="w-4 h-4 text-current" />
                         <span className="text-current">{link.label}</span>
                     </div>
@@ -161,17 +161,17 @@ export function CommandPalette({
                 className="fixed inset-0 bg-black/50"
                 onClick={() => onOpenChange(false)}
             />
-            <div className="relative bg-white dark:bg-zinc-950 border-2 border-black dark:border-zinc-200 w-full max-w-2xl mx-4 overflow-hidden shadow-[8px_8px_0_0_var(--color-black)] dark:shadow-[8px_8px_0_0_var(--color-zinc-200)]">
+            <div className="relative bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 w-full max-w-2xl mx-4 overflow-hidden shadow-lg shadow-black/10 dark:shadow-black/40">
                 {/* Navigation Header */}
-                <div className="flex items-center gap-3 px-6 py-4 border-b-2 border-black dark:border-zinc-200">
+                <div className="flex items-center gap-3 px-6 py-4 border-b border-zinc-200 dark:border-zinc-800">
                     <Home className="w-4 h-4 text-zinc-500 dark:text-zinc-400" />
-                    <span className="font-mono uppercase tracking-[0.2em] text-xs text-zinc-700 dark:text-zinc-300">
-                        Index
+                    <span className="font-medium tracking-wide text-xs text-zinc-700 dark:text-zinc-300">
+                        Navigate
                     </span>
                 </div>
 
                 {/* Main Search Input */}
-                <div className="p-6 border-b-2 border-black dark:border-zinc-200">
+                <div className="p-6 border-b border-zinc-200 dark:border-zinc-800">
                     <Command.Input
                         placeholder="Where would you like to go?"
                         className="w-full bg-transparent text-black dark:text-zinc-100 text-xl font-display font-semibold placeholder-zinc-400 dark:placeholder-zinc-500 border-none outline-none"

--- a/app/components/Divider.tsx
+++ b/app/components/Divider.tsx
@@ -8,7 +8,7 @@ export function Divider({ className }: DividerProps) {
     return (
         <hr
             className={cx(
-                'my-4 h-px border-0 bg-zinc-300 dark:bg-zinc-700',
+                'my-4 h-0.5 border-0 bg-black dark:bg-zinc-200',
                 className
             )}
         />

--- a/app/components/Divider.tsx
+++ b/app/components/Divider.tsx
@@ -8,7 +8,7 @@ export function Divider({ className }: DividerProps) {
     return (
         <hr
             className={cx(
-                'my-4 h-0.5 border-0 bg-black dark:bg-zinc-200',
+                'my-4 h-px border-0 bg-zinc-200 dark:bg-zinc-800',
                 className
             )}
         />

--- a/app/components/FormAlert.tsx
+++ b/app/components/FormAlert.tsx
@@ -17,7 +17,7 @@ export function FormAlert({
     return (
         <div
             role="alert"
-            className="border-2 border-tertiary-500 bg-tertiary-500/15 p-4"
+            className="rounded-xl border border-tertiary-500/50 bg-tertiary-500/10 p-4"
         >
             <div className="mb-2">
                 <TriangleAlert className="text-tertiary-600 dark:text-tertiary-400" />

--- a/app/components/FormAlert.tsx
+++ b/app/components/FormAlert.tsx
@@ -15,11 +15,16 @@ export function FormAlert({
     }
 
     return (
-        <div role="alert" className="rounded-lg border border-red-500 bg-red-500/15 p-4">
+        <div
+            role="alert"
+            className="border-2 border-tertiary-500 bg-tertiary-500/15 p-4"
+        >
             <div className="mb-2">
-                <TriangleAlert className="text-red-400" />
+                <TriangleAlert className="text-tertiary-600 dark:text-tertiary-400" />
             </div>
-            <p className="text-red-300">{children}</p>
+            <p className="text-tertiary-700 dark:text-tertiary-300">
+                {children}
+            </p>
         </div>
     );
 }

--- a/app/components/FormField.tsx
+++ b/app/components/FormField.tsx
@@ -23,18 +23,18 @@ export function FormField({
 }: FormFieldProps) {
     const errorId = `${name}-error`;
     const inputClasses = cx(
-        'p-3 border-2 w-full bg-transparent transition-colors duration-150',
+        'p-3 rounded-lg border w-full bg-transparent transition-colors duration-150',
         'focus:outline-none focus:ring-2 focus:ring-offset-2 ring-offset-white dark:ring-offset-zinc-950',
         error
             ? 'border-tertiary-500 focus:ring-tertiary-500'
-            : 'border-black dark:border-zinc-200 focus:ring-primary-500 dark:focus:ring-primary-400'
+            : 'border-zinc-300 dark:border-zinc-700 focus:ring-primary-500 dark:focus:ring-primary-400'
     );
 
     return (
         <div>
             <label
                 htmlFor={name}
-                className="block mb-2 font-mono uppercase tracking-[0.12em] text-xs font-semibold"
+                className="block mb-2 text-sm font-medium"
             >
                 {label}
             </label>

--- a/app/components/FormField.tsx
+++ b/app/components/FormField.tsx
@@ -1,5 +1,10 @@
 import { cx } from '~/cva.config';
 
+interface FormFieldOption {
+    value: string;
+    label: string;
+}
+
 interface FormFieldProps {
     label: string;
     name: string;
@@ -7,8 +12,10 @@ interface FormFieldProps {
     placeholder?: string;
     required?: boolean;
     error?: string;
-    as?: 'input' | 'textarea';
+    as?: 'input' | 'textarea' | 'select';
     rows?: number;
+    options?: FormFieldOption[];
+    defaultValue?: string;
 }
 
 export function FormField({
@@ -19,7 +26,9 @@ export function FormField({
     required,
     error,
     as = 'input',
-    rows
+    rows,
+    options,
+    defaultValue
 }: FormFieldProps) {
     const errorId = `${name}-error`;
     const inputClasses = cx(
@@ -38,7 +47,28 @@ export function FormField({
             >
                 {label}
             </label>
-            {as === 'textarea' ? (
+            {as === 'select' ? (
+                <select
+                    id={name}
+                    name={name}
+                    required={required}
+                    defaultValue={defaultValue ?? ''}
+                    className={cx(inputClasses, 'appearance-none pr-10')}
+                    aria-invalid={error ? true : undefined}
+                    aria-describedby={error ? errorId : undefined}
+                >
+                    {placeholder && (
+                        <option value="" disabled>
+                            {placeholder}
+                        </option>
+                    )}
+                    {options?.map((option) => (
+                        <option key={option.value} value={option.value}>
+                            {option.label}
+                        </option>
+                    ))}
+                </select>
+            ) : as === 'textarea' ? (
                 <textarea
                     id={name}
                     name={name}

--- a/app/components/FormField.tsx
+++ b/app/components/FormField.tsx
@@ -23,15 +23,19 @@ export function FormField({
 }: FormFieldProps) {
     const errorId = `${name}-error`;
     const inputClasses = cx(
-        'p-2 border rounded w-full',
+        'p-3 border-2 w-full bg-transparent transition-colors duration-150',
+        'focus:outline-none focus:ring-2 focus:ring-offset-2 ring-offset-white dark:ring-offset-zinc-950',
         error
-            ? 'border-red-500 focus:ring-red-500'
-            : 'border-zinc-500 focus:ring-primary-500'
+            ? 'border-tertiary-500 focus:ring-tertiary-500'
+            : 'border-black dark:border-zinc-200 focus:ring-primary-500 dark:focus:ring-primary-400'
     );
 
     return (
         <div>
-            <label htmlFor={name} className="block mb-2 font-medium">
+            <label
+                htmlFor={name}
+                className="block mb-2 font-mono uppercase tracking-[0.12em] text-xs font-semibold"
+            >
                 {label}
             </label>
             {as === 'textarea' ? (
@@ -58,7 +62,7 @@ export function FormField({
                 />
             )}
             {error && (
-                <p id={errorId} className="mt-1 text-sm text-red-400">{error}</p>
+                <p id={errorId} className="mt-1 text-sm text-tertiary-600 dark:text-tertiary-400">{error}</p>
             )}
         </div>
     );

--- a/app/components/Heading.tsx
+++ b/app/components/Heading.tsx
@@ -13,8 +13,8 @@ interface HeadingProps {
 const headingVariants = cva({
     variants: {
         size: {
-            '1': 'text-4xl md:text-5xl mb-6',
-            '2': 'text-3xl mb-4',
+            '1': 'text-5xl md:text-6xl mb-6',
+            '2': 'text-3xl md:text-4xl mb-4',
             '3': 'text-2xl mb-4',
             '4': 'text-xl',
             '5': 'text-lg',
@@ -39,7 +39,7 @@ export function Heading({
         <Component
             id={id}
             className={cx(
-                'font-bold text-zinc-700 dark:text-white',
+                'font-display font-black leading-[0.95] text-black dark:text-white',
                 headingVariants({ className, size })
             )}
         >

--- a/app/components/Heading.tsx
+++ b/app/components/Heading.tsx
@@ -39,7 +39,7 @@ export function Heading({
         <Component
             id={id}
             className={cx(
-                'font-display font-black leading-[0.95] text-black dark:text-white',
+                'font-display font-bold leading-[1.05] text-zinc-900 dark:text-zinc-50',
                 headingVariants({ className, size })
             )}
         >

--- a/app/components/HeroImage.tsx
+++ b/app/components/HeroImage.tsx
@@ -53,7 +53,7 @@ export function HeroImage({
     return (
         <figure
             className={cx(
-                'opacity-0 animate-fade-slide relative border-2 border-black dark:border-zinc-200 mb-8 overflow-hidden group',
+                'opacity-0 animate-fade-slide relative border border-zinc-200 dark:border-zinc-800 mb-8 overflow-hidden group',
                 aspectRatio,
                 clickable &&
                     'cursor-pointer hover:opacity-90 transition-opacity'
@@ -82,7 +82,7 @@ export function HeroImage({
             />
 
             {showGalleryBadge && (
-                <div className="absolute bottom-4 right-4 flex items-center gap-2 px-3 py-2 bg-black text-white border-2 border-white font-mono text-xs uppercase tracking-[0.15em]">
+                <div className="absolute bottom-4 right-4 flex items-center gap-2 px-3 py-2 rounded-lg bg-black/75 backdrop-blur-sm text-white text-xs font-medium">
                     <Images className="w-4 h-4" />
                     <span>{imageCount} images</span>
                 </div>
@@ -90,7 +90,7 @@ export function HeroImage({
 
             {clickable && (
                 <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/20 pointer-events-none">
-                    <div className="px-4 py-2.5 bg-black text-white border-2 border-white font-mono text-xs uppercase tracking-[0.15em]">
+                    <div className="px-4 py-2.5 rounded-lg bg-black/75 backdrop-blur-sm text-white text-xs font-medium">
                         View gallery
                     </div>
                 </div>

--- a/app/components/HeroImage.tsx
+++ b/app/components/HeroImage.tsx
@@ -53,7 +53,7 @@ export function HeroImage({
     return (
         <figure
             className={cx(
-                'opacity-0 animate-fade-slide relative border-b mb-8 border-b-zinc-300 dark:border-b-zinc-700 overflow-hidden group',
+                'opacity-0 animate-fade-slide relative border-2 border-black dark:border-zinc-200 mb-8 overflow-hidden group',
                 aspectRatio,
                 clickable &&
                     'cursor-pointer hover:opacity-90 transition-opacity'
@@ -82,16 +82,16 @@ export function HeroImage({
             />
 
             {showGalleryBadge && (
-                <div className="absolute bottom-4 right-4 flex items-center gap-2 px-4 py-2.5 rounded-lg bg-black/80 backdrop-blur-sm text-white text-base font-medium transition-all group-hover:bg-black/90 group-hover:scale-105 animate-pulse-subtle shadow-[0_0_20px_rgba(255,255,255,0.15)]">
-                    <Images className="w-5 h-5" />
+                <div className="absolute bottom-4 right-4 flex items-center gap-2 px-3 py-2 bg-black text-white border-2 border-white font-mono text-xs uppercase tracking-[0.15em]">
+                    <Images className="w-4 h-4" />
                     <span>{imageCount} images</span>
                 </div>
             )}
 
             {clickable && (
                 <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity bg-black/20 pointer-events-none">
-                    <div className="px-5 py-3 rounded-lg bg-black/80 backdrop-blur-sm text-white font-medium">
-                        Click to view gallery
+                    <div className="px-4 py-2.5 bg-black text-white border-2 border-white font-mono text-xs uppercase tracking-[0.15em]">
+                        View gallery
                     </div>
                 </div>
             )}

--- a/app/components/KeyboardShortcut.tsx
+++ b/app/components/KeyboardShortcut.tsx
@@ -10,7 +10,7 @@ export function KeyboardShortcut({ keys, className }: KeyboardShortcutProps) {
         <span className={cx(`inline-flex items-center gap-1`, className)}>
             {keys.map((key, index) => (
                 <span key={index} className="inline-flex items-center">
-                    <kbd className="px-2 py-0.5 text-xs bg-transparent text-black dark:text-white border-2 border-black dark:border-zinc-200 font-mono uppercase">
+                    <kbd className="px-2 py-0.5 text-xs bg-transparent text-black dark:text-white border border-zinc-200 dark:border-zinc-800 font-mono uppercase">
                         {key}
                     </kbd>
                     {index < keys.length - 1 && (

--- a/app/components/KeyboardShortcut.tsx
+++ b/app/components/KeyboardShortcut.tsx
@@ -10,11 +10,11 @@ export function KeyboardShortcut({ keys, className }: KeyboardShortcutProps) {
         <span className={cx(`inline-flex items-center gap-1`, className)}>
             {keys.map((key, index) => (
                 <span key={index} className="inline-flex items-center">
-                    <kbd className="px-2 py-1 text-xs bg-zinc-200 dark:bg-zinc-900 text-zinc-900 dark:text-white rounded border border-zinc-600 font-mono">
+                    <kbd className="px-2 py-0.5 text-xs bg-transparent text-black dark:text-white border-2 border-black dark:border-zinc-200 font-mono uppercase">
                         {key}
                     </kbd>
                     {index < keys.length - 1 && (
-                        <span className="mx-1 text-zinc-700 dark:text-white">
+                        <span className="mx-1 text-zinc-700 dark:text-zinc-300 font-mono">
                             +
                         </span>
                     )}

--- a/app/components/Linky.tsx
+++ b/app/components/Linky.tsx
@@ -6,13 +6,20 @@ import { Link } from 'react-router';
 import { cva, cx } from '~/cva.config';
 
 export const linkyVariants = cva({
-    base: 'inline-flex cursor-pointer items-center gap-1.5 transition-colors duration-200 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950',
+    base: 'inline-flex cursor-pointer items-center gap-1.5 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950',
     variants: {
         variant: {
-            inline: 'text-primary-400 hover:text-primary-300',
-            muted: 'text-zinc-400 hover:text-zinc-200',
-            underline:
-                'text-primary-400 hover:text-primary-300 underline underline-offset-4 decoration-primary-500/40 hover:decoration-primary-400'
+            inline: [
+                'text-black dark:text-white underline decoration-2 underline-offset-4',
+                'decoration-primary-600 dark:decoration-primary-400',
+                'hover:bg-primary-400 hover:text-black hover:decoration-transparent dark:hover:text-black'
+            ],
+            muted: 'text-zinc-500 hover:text-black dark:text-zinc-400 dark:hover:text-white underline decoration-zinc-400/60 underline-offset-4 hover:decoration-current',
+            underline: [
+                'text-black dark:text-white underline decoration-2 underline-offset-4',
+                'decoration-primary-600 dark:decoration-primary-400',
+                'hover:bg-primary-400 hover:text-black hover:decoration-transparent dark:hover:text-black'
+            ]
         }
     },
     defaultVariants: {

--- a/app/components/Linky.tsx
+++ b/app/components/Linky.tsx
@@ -10,15 +10,15 @@ export const linkyVariants = cva({
     variants: {
         variant: {
             inline: [
-                'text-black dark:text-white underline decoration-2 underline-offset-4',
-                'decoration-primary-600 dark:decoration-primary-400',
-                'hover:bg-primary-400 hover:text-black hover:decoration-transparent dark:hover:text-black'
+                'text-zinc-900 dark:text-zinc-100 underline underline-offset-4',
+                'decoration-primary-500/60',
+                'hover:text-primary-700 dark:hover:text-primary-300 hover:decoration-primary-500'
             ],
             muted: 'text-zinc-500 hover:text-black dark:text-zinc-400 dark:hover:text-white underline decoration-zinc-400/60 underline-offset-4 hover:decoration-current',
             underline: [
-                'text-black dark:text-white underline decoration-2 underline-offset-4',
-                'decoration-primary-600 dark:decoration-primary-400',
-                'hover:bg-primary-400 hover:text-black hover:decoration-transparent dark:hover:text-black'
+                'text-zinc-900 dark:text-zinc-100 underline underline-offset-4',
+                'decoration-primary-500/60',
+                'hover:text-primary-700 dark:hover:text-primary-300 hover:decoration-primary-500'
             ]
         }
     },

--- a/app/components/MdxContent.tsx
+++ b/app/components/MdxContent.tsx
@@ -50,7 +50,7 @@ const mdxComponents: Record<string, ComponentType<any>> = {
         }
         // Inline code
         return (
-            <code className="bg-zinc-100 dark:bg-zinc-800 px-2 py-1.5 rounded text-zinc-900 dark:text-zinc-50 font-mono text-sm border border-zinc-300 dark:border-zinc-700">
+            <code className="bg-primary-400/25 px-1.5 py-0.5 text-black dark:text-zinc-50 font-mono text-sm border border-black/40 dark:border-zinc-200/40">
                 {children}
             </code>
         );
@@ -63,7 +63,7 @@ interface MdxContentProps {
 
 export function MdxContent({ Component }: MdxContentProps) {
     return (
-        <div className="prose prose-lg max-w-none dark:prose-invert prose-code:before:content-[''] prose-code:after:content-[''] prose-headings:my-4 prose-pre:p-0 prose-pre:bg-none">
+        <div className="prose prose-lg max-w-none dark:prose-invert prose-code:before:content-[''] prose-code:after:content-[''] prose-headings:my-4 prose-headings:font-display prose-headings:font-black prose-pre:p-0 prose-pre:bg-none prose-blockquote:border-l-4 prose-blockquote:border-primary-500 prose-blockquote:not-italic prose-hr:border-t-2 prose-hr:border-black dark:prose-hr:border-zinc-200">
             <Component components={mdxComponents} />
         </div>
     );

--- a/app/components/MdxContent.tsx
+++ b/app/components/MdxContent.tsx
@@ -50,7 +50,7 @@ const mdxComponents: Record<string, ComponentType<any>> = {
         }
         // Inline code
         return (
-            <code className="bg-primary-400/25 px-1.5 py-0.5 text-black dark:text-zinc-50 font-mono text-sm border border-black/40 dark:border-zinc-200/40">
+            <code className="bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded text-zinc-900 dark:text-zinc-50 font-mono text-sm">
                 {children}
             </code>
         );
@@ -63,7 +63,7 @@ interface MdxContentProps {
 
 export function MdxContent({ Component }: MdxContentProps) {
     return (
-        <div className="prose prose-lg max-w-none dark:prose-invert prose-code:before:content-[''] prose-code:after:content-[''] prose-headings:my-4 prose-headings:font-display prose-headings:font-black prose-pre:p-0 prose-pre:bg-none prose-blockquote:border-l-4 prose-blockquote:border-primary-500 prose-blockquote:not-italic prose-hr:border-t-2 prose-hr:border-black dark:prose-hr:border-zinc-200">
+        <div className="prose prose-lg max-w-none dark:prose-invert prose-code:before:content-[''] prose-code:after:content-[''] prose-headings:my-4 prose-headings:font-display prose-headings:font-bold prose-pre:p-0 prose-pre:bg-none prose-blockquote:border-l-4 prose-blockquote:border-primary-500 prose-blockquote:not-italic prose-hr:border-zinc-200 dark:prose-hr:border-zinc-800">
             <Component components={mdxComponents} />
         </div>
     );

--- a/app/components/ServiceLanding.tsx
+++ b/app/components/ServiceLanding.tsx
@@ -38,13 +38,13 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
             <section className="pt-4">
                 <Link
                     to="/services"
-                    className="inline-flex items-center gap-1 font-mono text-xs uppercase tracking-[0.15em] text-zinc-600 dark:text-zinc-400 hover:bg-primary-400 hover:text-black px-2 py-1 mb-6"
+                    className="inline-flex items-center gap-1 text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400 hover:text-primary-700 dark:hover:text-primary-300 px-2 py-1 mb-6"
                 >
                     <ArrowRight className="size-4 rotate-180" />
                     All services
                 </Link>
                 <div className="flex flex-wrap items-center gap-2 mb-6">
-                    <span className="inline-flex items-center gap-1.5 bg-primary-400 text-black px-3 py-1 font-mono text-xs uppercase tracking-[0.12em]">
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-primary-500/15 text-primary-800 dark:text-primary-300 px-3 py-1 text-xs font-medium">
                         <Tag className="size-3.5" />
                         Starting at {offer.startingPrice}
                     </span>
@@ -84,7 +84,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     {offer.idealFor.map((item) => (
                         <li
                             key={item}
-                            className="flex items-start gap-3 rounded-lg border-2 border-black dark:border-zinc-200 p-4"
+                            className="flex items-start gap-3 rounded-lg border border-zinc-200 dark:border-zinc-800 p-4"
                         >
                             <CheckCircle2 className="size-5 text-primary-400 mt-0.5 shrink-0" />
                             <span className="text-zinc-200">{item}</span>
@@ -101,7 +101,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     {offer.deliverables.map((item) => (
                         <li
                             key={item}
-                            className="flex items-start gap-3 rounded-lg border-2 border-black dark:border-zinc-200 p-4"
+                            className="flex items-start gap-3 rounded-lg border border-zinc-200 dark:border-zinc-800 p-4"
                         >
                             <span className="size-1.5 rounded-full bg-tertiary-400 mt-2.5 shrink-0" />
                             <span className="text-zinc-200">{item}</span>
@@ -118,7 +118,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     {offer.scopeExamples.map((example) => (
                         <div
                             key={example.name}
-                            className="rounded-lg border-2 border-black dark:border-zinc-200 p-6"
+                            className="rounded-lg border border-zinc-200 dark:border-zinc-800 p-6"
                         >
                             <Heading as="h3" size="5" className="mb-2 text-primary-300">
                                 {example.name}
@@ -139,7 +139,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     {offer.process.map((step, index) => (
                         <li
                             key={step.step}
-                            className="flex gap-5 rounded-lg border-2 border-black dark:border-zinc-200 p-5"
+                            className="flex gap-5 rounded-lg border border-zinc-200 dark:border-zinc-800 p-5"
                         >
                             <span className="font-black text-3xl text-primary-500/60 leading-none shrink-0 w-10">
                                 0{index + 1}
@@ -172,7 +172,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                             <Link
                                 key={work.slug}
                                 to={`/work/${work.slug}`}
-                                className="group overflow-hidden border-2 border-black dark:border-zinc-200 transition-shadow duration-150 hover:shadow-[6px_6px_0_0_var(--color-black)] dark:hover:shadow-[6px_6px_0_0_var(--color-zinc-200)] flex flex-col"
+                                className="group overflow-hidden border border-zinc-200 dark:border-zinc-800 transition-shadow duration-150 hover:border-primary-500/60 flex flex-col"
                             >
                                 {work.thumbnailImage && (
                                     <div className="aspect-video overflow-hidden">
@@ -209,7 +209,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     {offer.faq.map((item) => (
                         <details
                             key={item.question}
-                            className="group border-2 border-black dark:border-zinc-200 p-5 open:border-primary-600 dark:open:border-primary-400"
+                            className="group border border-zinc-200 dark:border-zinc-800 p-5 open:border-primary-600 dark:open:border-primary-400"
                         >
                             <summary className="cursor-pointer list-none flex items-start justify-between gap-4">
                                 <span className="font-semibold text-zinc-100">
@@ -227,7 +227,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
 
             <section
                 id="start"
-                className="border-2 border-black dark:border-zinc-200 p-8 md:p-10"
+                className="border border-zinc-200 dark:border-zinc-800 p-8 md:p-10"
             >
                 <div className="max-w-xl">
                     <Heading as="h2" size="3" className="mb-3">

--- a/app/components/ServiceLanding.tsx
+++ b/app/components/ServiceLanding.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, CheckCircle2, LoaderIcon, Tag } from 'lucide-react';
+import { ArrowRight, CheckCircle2, LoaderIcon } from 'lucide-react';
 import { Link, useFetcher } from 'react-router';
 import { useEffect, useRef } from 'react';
 
@@ -11,6 +11,23 @@ import type { ContactFieldErrors } from '~/schemas/contact';
 import type { ServiceOffer } from '~/content/data/service-offers';
 import type { WorkFrontmatter } from '~/content/types';
 import { cx } from '~/cva.config';
+
+const SCOPE_CALL_URL = 'https://tidycal.com/sethdavis512/meet-and-greet';
+
+const BUDGET_OPTIONS = [
+    { value: 'Under $5k', label: 'Under $5k' },
+    { value: '$5k to $15k', label: '$5k to $15k' },
+    { value: '$15k to $50k', label: '$15k to $50k' },
+    { value: '$50k+', label: '$50k+' },
+    { value: 'Not sure yet', label: 'Not sure yet' }
+];
+
+const TIMELINE_OPTIONS = [
+    { value: 'As soon as possible', label: 'As soon as possible' },
+    { value: 'Within a month', label: 'Within a month' },
+    { value: 'This quarter', label: 'This quarter' },
+    { value: 'Exploring', label: 'Just exploring' }
+];
 
 interface ServiceLandingProps {
     offer: ServiceOffer;
@@ -33,6 +50,9 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
         }
     }, [fetcher.data]);
 
+    const kindLabel =
+        offer.kind === 'retainer' ? 'Ongoing retainer' : 'Project engagement';
+
     return (
         <article className="space-y-16">
             <section className="pt-4">
@@ -43,51 +63,48 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     <ArrowRight className="size-4 rotate-180" />
                     All services
                 </Link>
-                <div className="flex flex-wrap items-center gap-2 mb-6">
-                    <span className="inline-flex items-center gap-1.5 rounded-full bg-primary-500/15 text-primary-800 dark:text-primary-300 px-3 py-1 text-xs font-medium">
-                        <Tag className="size-3.5" />
-                        Starting at {offer.startingPrice}
-                    </span>
-                </div>
-                <Heading as="h1" className="text-4xl md:text-6xl font-black mb-6">
+                <p className="text-xs font-medium tracking-wide text-primary-700 dark:text-primary-300 mb-4">
+                    {kindLabel}
+                </p>
+                <Heading as="h1" className="text-4xl md:text-6xl mb-6">
                     {offer.title}
                 </Heading>
-                <p className="text-xl md:text-2xl text-zinc-700 dark:text-zinc-300 max-w-3xl mb-8">
+                <p className="text-xl md:text-2xl text-zinc-700 dark:text-zinc-300 max-w-3xl mb-4">
                     {offer.tagline}
                 </p>
+                {offer.proofLine && (
+                    <p className="text-sm text-zinc-500 mb-8 max-w-3xl">
+                        {offer.proofLine}
+                    </p>
+                )}
                 <div className="flex flex-wrap gap-3">
                     <Button
-                        to={`#start`}
+                        href={SCOPE_CALL_URL}
                         size="lg"
                         iconAfter={<ArrowRight className="size-4" />}
                     >
-                        Start a project
-                    </Button>
-                    <Button
-                        href="https://tidycal.com/sethdavis512/meet-and-greet"
-                        size="lg"
-                        variant="outline"
-                    >
                         Book a scope call
                     </Button>
+                    <Button to="#inquiry" size="lg" variant="outline">
+                        Send an inquiry
+                    </Button>
                 </div>
-                {offer.proofLine && (
-                    <p className="mt-6 text-sm text-zinc-500">{offer.proofLine}</p>
-                )}
             </section>
 
             <section>
                 <Heading as="h2" size="3" className="mb-6">
-                    Ideal for
+                    Who this is for
                 </Heading>
                 <ul className="grid gap-3 md:grid-cols-2">
                     {offer.idealFor.map((item) => (
                         <li
                             key={item}
-                            className="flex items-start gap-3 rounded-lg border border-zinc-200 dark:border-zinc-800 p-4"
+                            className="flex items-start gap-3 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4"
                         >
-                            <CheckCircle2 className="size-5 text-primary-400 mt-0.5 shrink-0" />
-                            <span className="text-zinc-200">{item}</span>
+                            <CheckCircle2 className="size-5 text-primary-600 dark:text-primary-400 mt-0.5 shrink-0" />
+                            <span className="text-zinc-700 dark:text-zinc-300">
+                                {item}
+                            </span>
                         </li>
                     ))}
                 </ul>
@@ -101,10 +118,12 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     {offer.deliverables.map((item) => (
                         <li
                             key={item}
-                            className="flex items-start gap-3 rounded-lg border border-zinc-200 dark:border-zinc-800 p-4"
+                            className="flex items-start gap-3 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-4"
                         >
-                            <span className="size-1.5 rounded-full bg-tertiary-400 mt-2.5 shrink-0" />
-                            <span className="text-zinc-200">{item}</span>
+                            <span className="size-1.5 rounded-full bg-tertiary-500 dark:bg-tertiary-400 mt-2.5 shrink-0" />
+                            <span className="text-zinc-700 dark:text-zinc-300">
+                                {item}
+                            </span>
                         </li>
                     ))}
                 </ul>
@@ -112,18 +131,22 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
 
             <section>
                 <Heading as="h2" size="3" className="mb-6">
-                    What an engagement looks like
+                    {offer.scopeHeading ?? 'What an engagement looks like'}
                 </Heading>
                 <div className="grid gap-4 md:grid-cols-3">
                     {offer.scopeExamples.map((example) => (
                         <div
                             key={example.name}
-                            className="rounded-lg border border-zinc-200 dark:border-zinc-800 p-6"
+                            className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-6"
                         >
-                            <Heading as="h3" size="5" className="mb-2 text-primary-300">
+                            <Heading
+                                as="h3"
+                                size="5"
+                                className="mb-2 text-primary-700 dark:text-primary-300"
+                            >
                                 {example.name}
                             </Heading>
-                            <p className="text-zinc-300 text-sm leading-relaxed">
+                            <p className="text-zinc-600 dark:text-zinc-300 text-sm leading-relaxed">
                                 {example.description}
                             </p>
                         </div>
@@ -133,22 +156,24 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
 
             <section>
                 <Heading as="h2" size="3" className="mb-6">
-                    How it works
+                    {offer.processHeading ?? 'How it works'}
                 </Heading>
                 <ol className="space-y-4">
                     {offer.process.map((step, index) => (
                         <li
                             key={step.step}
-                            className="flex gap-5 rounded-lg border border-zinc-200 dark:border-zinc-800 p-5"
+                            className="flex gap-5 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-5"
                         >
-                            <span className="font-black text-3xl text-primary-500/60 leading-none shrink-0 w-10">
+                            <span className="font-display font-bold text-3xl text-primary-500/70 leading-none shrink-0 w-10">
                                 0{index + 1}
                             </span>
                             <div>
                                 <Heading as="h3" size="5" className="mb-1">
                                     {step.step}
                                 </Heading>
-                                <p className="text-zinc-300">{step.description}</p>
+                                <p className="text-zinc-600 dark:text-zinc-300">
+                                    {step.description}
+                                </p>
                             </div>
                         </li>
                     ))}
@@ -172,7 +197,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                             <Link
                                 key={work.slug}
                                 to={`/work/${work.slug}`}
-                                className="group overflow-hidden border border-zinc-200 dark:border-zinc-800 transition-shadow duration-150 hover:border-primary-500/60 flex flex-col"
+                                className="group overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 transition-colors duration-200 hover:border-primary-500/60 flex flex-col"
                             >
                                 {work.thumbnailImage && (
                                     <div className="aspect-video overflow-hidden">
@@ -187,10 +212,10 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                                     <Heading as="h3" size="4" className="mb-2">
                                         {work.title}
                                     </Heading>
-                                    <p className="text-sm text-zinc-400 line-clamp-3 mb-3">
+                                    <p className="text-sm text-zinc-600 dark:text-zinc-400 line-clamp-3 mb-3">
                                         {work.description}
                                     </p>
-                                    <span className="text-sm text-primary-400 mt-auto inline-flex items-center gap-1">
+                                    <span className="text-sm text-primary-700 dark:text-primary-300 mt-auto inline-flex items-center gap-1">
                                         Read the case study
                                         <ArrowRight className="size-3.5" />
                                     </span>
@@ -209,15 +234,15 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     {offer.faq.map((item) => (
                         <details
                             key={item.question}
-                            className="group border border-zinc-200 dark:border-zinc-800 p-5 open:border-primary-600 dark:open:border-primary-400"
+                            className="group rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-5 open:border-primary-500/60"
                         >
                             <summary className="cursor-pointer list-none flex items-start justify-between gap-4">
-                                <span className="font-semibold text-zinc-100">
+                                <span className="font-semibold text-zinc-900 dark:text-zinc-100">
                                     {item.question}
                                 </span>
                                 <ArrowRight className="size-4 shrink-0 mt-1 text-zinc-500 transition-transform duration-200 group-open:rotate-90" />
                             </summary>
-                            <p className="mt-3 text-zinc-300 leading-relaxed">
+                            <p className="mt-3 text-zinc-600 dark:text-zinc-300 leading-relaxed">
                                 {item.answer}
                             </p>
                         </details>
@@ -226,21 +251,20 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
             </section>
 
             <section
-                id="start"
-                className="border border-zinc-200 dark:border-zinc-800 p-8 md:p-10"
+                id="inquiry"
+                className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/60 p-8 md:p-10"
             >
                 <div className="max-w-xl">
                     <Heading as="h2" size="3" className="mb-3">
-                        Start a project
+                        Start the conversation
                     </Heading>
-                    <p className="text-zinc-300 mb-6">
-                        Tell me about what you're building. I'll reply within
-                        one business day with questions and whether this is a
-                        good fit. Prefer to talk?{' '}
-                        <Linky href="https://tidycal.com/sethdavis512/meet-and-greet">
-                            Book a 30-minute scope call
+                    <p className="text-zinc-600 dark:text-zinc-300 mb-6">
+                        The fastest path is a{' '}
+                        <Linky href={SCOPE_CALL_URL}>
+                            free 30-minute scope call
                         </Linky>
-                        .
+                        . Prefer to write it out? Use the form and I'll reply
+                        within one business day.
                     </p>
                 </div>
                 <fetcher.Form
@@ -251,11 +275,12 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     <input type="hidden" name="offer" value={offer.slug} />
                     {fetcher.data?.success ? (
                         <FormAlert variant="success">
-                            Thanks. Your request is in. I'll be in touch within one business day.
+                            Thanks. Your inquiry is in. I'll be in touch within
+                            one business day.
                         </FormAlert>
                     ) : fetcher.data?.error ? (
                         <FormAlert variant="error">
-                            There was an error sending your request.
+                            There was an error sending your inquiry.
                             <br />
                             Please try again later.
                         </FormAlert>
@@ -285,11 +310,35 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                         error={fetcher.data?.fieldErrors?.email}
                     />
                     <FormField
-                        label={`Tell me about your ${offer.shortTitle.toLowerCase()} project`}
+                        label="Company (optional)"
+                        name="company"
+                        placeholder="Where you work"
+                        error={fetcher.data?.fieldErrors?.company}
+                    />
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <FormField
+                            label="Budget range"
+                            name="budget"
+                            as="select"
+                            placeholder="Select a range"
+                            options={BUDGET_OPTIONS}
+                            error={fetcher.data?.fieldErrors?.budget}
+                        />
+                        <FormField
+                            label="Timeline"
+                            name="timeline"
+                            as="select"
+                            placeholder="Select a timeline"
+                            options={TIMELINE_OPTIONS}
+                            error={fetcher.data?.fieldErrors?.timeline}
+                        />
+                    </div>
+                    <FormField
+                        label="What are you looking to build?"
                         name="note"
                         as="textarea"
                         rows={5}
-                        placeholder="What are you trying to build? What's the context?"
+                        placeholder="The project, the team, the context. A few sentences is plenty."
                         error={fetcher.data?.fieldErrors?.note}
                     />
                     <Button
@@ -302,7 +351,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                             ) : undefined
                         }
                     >
-                        {fetcher.state !== 'idle' ? 'Sending...' : 'Send request'}
+                        {fetcher.state !== 'idle' ? 'Sending...' : 'Send inquiry'}
                     </Button>
                 </fetcher.Form>
             </section>

--- a/app/components/ServiceLanding.tsx
+++ b/app/components/ServiceLanding.tsx
@@ -38,13 +38,13 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
             <section className="pt-4">
                 <Link
                     to="/services"
-                    className="inline-flex items-center gap-1 text-sm text-zinc-400 hover:text-primary-400 mb-6"
+                    className="inline-flex items-center gap-1 font-mono text-xs uppercase tracking-[0.15em] text-zinc-600 dark:text-zinc-400 hover:bg-primary-400 hover:text-black px-2 py-1 mb-6"
                 >
                     <ArrowRight className="size-4 rotate-180" />
                     All services
                 </Link>
                 <div className="flex flex-wrap items-center gap-2 mb-6">
-                    <span className="inline-flex items-center gap-1.5 rounded-full bg-primary-500/15 text-primary-300 px-3 py-1 text-sm font-medium">
+                    <span className="inline-flex items-center gap-1.5 bg-primary-400 text-black px-3 py-1 font-mono text-xs uppercase tracking-[0.12em]">
                         <Tag className="size-3.5" />
                         Starting at {offer.startingPrice}
                     </span>
@@ -52,7 +52,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                 <Heading as="h1" className="text-4xl md:text-6xl font-black mb-6">
                     {offer.title}
                 </Heading>
-                <p className="text-xl md:text-2xl text-zinc-300 max-w-3xl mb-8">
+                <p className="text-xl md:text-2xl text-zinc-700 dark:text-zinc-300 max-w-3xl mb-8">
                     {offer.tagline}
                 </p>
                 <div className="flex flex-wrap gap-3">
@@ -84,7 +84,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     {offer.idealFor.map((item) => (
                         <li
                             key={item}
-                            className="flex items-start gap-3 rounded-lg bg-zinc-900 border border-zinc-800 p-4"
+                            className="flex items-start gap-3 rounded-lg border-2 border-black dark:border-zinc-200 p-4"
                         >
                             <CheckCircle2 className="size-5 text-primary-400 mt-0.5 shrink-0" />
                             <span className="text-zinc-200">{item}</span>
@@ -101,7 +101,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     {offer.deliverables.map((item) => (
                         <li
                             key={item}
-                            className="flex items-start gap-3 rounded-lg bg-zinc-900/60 border border-zinc-800 p-4"
+                            className="flex items-start gap-3 rounded-lg border-2 border-black dark:border-zinc-200 p-4"
                         >
                             <span className="size-1.5 rounded-full bg-tertiary-400 mt-2.5 shrink-0" />
                             <span className="text-zinc-200">{item}</span>
@@ -118,7 +118,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     {offer.scopeExamples.map((example) => (
                         <div
                             key={example.name}
-                            className="rounded-lg bg-zinc-900 border border-zinc-800 p-6"
+                            className="rounded-lg border-2 border-black dark:border-zinc-200 p-6"
                         >
                             <Heading as="h3" size="5" className="mb-2 text-primary-300">
                                 {example.name}
@@ -139,7 +139,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     {offer.process.map((step, index) => (
                         <li
                             key={step.step}
-                            className="flex gap-5 rounded-lg bg-zinc-900/60 border border-zinc-800 p-5"
+                            className="flex gap-5 rounded-lg border-2 border-black dark:border-zinc-200 p-5"
                         >
                             <span className="font-black text-3xl text-primary-500/60 leading-none shrink-0 w-10">
                                 0{index + 1}
@@ -172,7 +172,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                             <Link
                                 key={work.slug}
                                 to={`/work/${work.slug}`}
-                                className="group rounded-lg overflow-hidden bg-zinc-900 border border-zinc-800 hover:border-primary-500/40 transition-colors duration-200 flex flex-col"
+                                className="group overflow-hidden border-2 border-black dark:border-zinc-200 transition-shadow duration-150 hover:shadow-[6px_6px_0_0_var(--color-black)] dark:hover:shadow-[6px_6px_0_0_var(--color-zinc-200)] flex flex-col"
                             >
                                 {work.thumbnailImage && (
                                     <div className="aspect-video overflow-hidden">
@@ -209,7 +209,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
                     {offer.faq.map((item) => (
                         <details
                             key={item.question}
-                            className="group rounded-lg bg-zinc-900/60 border border-zinc-800 p-5 open:border-primary-500/40"
+                            className="group border-2 border-black dark:border-zinc-200 p-5 open:border-primary-600 dark:open:border-primary-400"
                         >
                             <summary className="cursor-pointer list-none flex items-start justify-between gap-4">
                                 <span className="font-semibold text-zinc-100">
@@ -227,7 +227,7 @@ export function ServiceLanding({ offer, caseStudies }: ServiceLandingProps) {
 
             <section
                 id="start"
-                className="rounded-xl bg-gradient-to-br from-zinc-900 via-zinc-900 to-primary-950/40 border border-zinc-800 p-8 md:p-10"
+                className="border-2 border-black dark:border-zinc-200 p-8 md:p-10"
             >
                 <div className="max-w-xl">
                     <Heading as="h2" size="3" className="mb-3">

--- a/app/components/ServicesCallToAction.tsx
+++ b/app/components/ServicesCallToAction.tsx
@@ -16,11 +16,12 @@ export function ServicesCallToAction({
             <div className="flex flex-col gap-4 p-6 md:flex-row md:items-center md:justify-between">
                 <div className="space-y-2">
                     <Heading as="h2" size="4">
-                        Looking for a technical partner on your next project?
+                        Need a design engineer on your next project?
                     </Heading>
                     <p className="text-sm text-zinc-600 dark:text-zinc-300">
-                        I build CLI tools and Contentful-powered websites
-                        on React Router 7. Fixed scope, fixed price.
+                        Marketing sites, design systems, AI prototypes, and
+                        fractional engagements. Every project starts with a
+                        free scope call.
                     </p>
                 </div>
                 <Button to="/services" color="primary" className="shrink-0">

--- a/app/components/ServicesCallToAction.tsx
+++ b/app/components/ServicesCallToAction.tsx
@@ -11,14 +11,14 @@ export function ServicesCallToAction({
 }: ServicesCallToActionProps) {
     return (
         <Card
-            className={`overflow-hidden bg-black text-white dark:bg-zinc-900 ${className ?? ''}`.trim()}
+            className={`overflow-hidden bg-zinc-50 dark:bg-zinc-900 ${className ?? ''}`.trim()}
         >
             <div className="flex flex-col gap-4 p-6 md:flex-row md:items-center md:justify-between">
                 <div className="space-y-2">
-                    <Heading as="h2" size="4" className="text-white">
+                    <Heading as="h2" size="4">
                         Looking for a technical partner on your next project?
                     </Heading>
-                    <p className="text-sm text-zinc-300">
+                    <p className="text-sm text-zinc-600 dark:text-zinc-300">
                         I build CLI tools and Contentful-powered websites
                         on React Router 7. Fixed scope, fixed price.
                     </p>

--- a/app/components/ServicesCallToAction.tsx
+++ b/app/components/ServicesCallToAction.tsx
@@ -11,7 +11,7 @@ export function ServicesCallToAction({
 }: ServicesCallToActionProps) {
     return (
         <Card
-            className={`overflow-hidden bg-zinc-900 text-white ${className ?? ''}`.trim()}
+            className={`overflow-hidden bg-black text-white dark:bg-zinc-900 ${className ?? ''}`.trim()}
         >
             <div className="flex flex-col gap-4 p-6 md:flex-row md:items-center md:justify-between">
                 <div className="space-y-2">

--- a/app/components/SkillTag.tsx
+++ b/app/components/SkillTag.tsx
@@ -12,7 +12,7 @@ export function SkillTag({
     children
 }: PropsWithChildren<SkillTagProps>) {
     return (
-        <Tag variant="primary" className={cx(className)}>
+        <Tag variant="secondary" className={cx(className)}>
             {children}
         </Tag>
     );

--- a/app/components/SlideCode.tsx
+++ b/app/components/SlideCode.tsx
@@ -72,7 +72,7 @@ export function SlideCode({ code, language = 'typescript', className }: Props) {
                 className
             )}
         >
-            <div className="absolute top-2 right-3 sm:top-4 sm:right-5 text-[0.6rem] sm:text-[0.7rem] font-mono uppercase tracking-[0.2em] text-zinc-500 pointer-events-none">
+            <div className="absolute top-2 right-3 sm:top-4 sm:right-5 text-[0.6rem] sm:text-[0.7rem] font-medium tracking-wide text-zinc-500 pointer-events-none">
                 {language}
             </div>
             <div

--- a/app/components/Tag.tsx
+++ b/app/components/Tag.tsx
@@ -4,14 +4,14 @@ import type { VariantProps } from 'cva';
 import { Card } from './Card';
 
 export const tagVariants = cva({
-    base: 'text-sm inline-block px-2 py-1',
+    base: 'inline-block px-2 py-1 font-mono uppercase tracking-[0.12em] text-xs',
     variants: {
         variant: {
             primary:
-                'dark:bg-primary-700/35 dark:border-primary-500 bg-primary-400/35 border-primary-500',
+                'bg-primary-400 dark:bg-primary-400 border-black dark:border-black text-black dark:text-black',
             secondary:
-                'dark:bg-secondary-700/35 dark:border-secondary-500 bg-secondary-400/35 border-secondary-500',
-            muted: 'dark:bg-zinc-700/35 dark:border-zinc-700 bg-zinc-300 border-zinc-700 text-zinc-900 dark:text-white'
+                'bg-transparent border-black text-black dark:border-zinc-200 dark:text-zinc-100',
+            muted: 'bg-transparent border-zinc-500 text-zinc-600 dark:text-zinc-400'
         }
     },
     defaultVariants: {

--- a/app/components/Tag.tsx
+++ b/app/components/Tag.tsx
@@ -4,14 +4,14 @@ import type { VariantProps } from 'cva';
 import { Card } from './Card';
 
 export const tagVariants = cva({
-    base: 'inline-block px-2 py-1 font-mono uppercase tracking-[0.12em] text-xs',
+    base: 'inline-block px-2 py-1 font-medium text-xs',
     variants: {
         variant: {
             primary:
-                'bg-primary-400 dark:bg-primary-400 border-black dark:border-black text-black dark:text-black',
+                'bg-primary-500/15 border-transparent text-primary-800 dark:text-primary-300',
             secondary:
-                'bg-transparent border-black text-black dark:border-zinc-200 dark:text-zinc-100',
-            muted: 'bg-transparent border-zinc-500 text-zinc-600 dark:text-zinc-400'
+                'bg-transparent border-zinc-300 text-zinc-700 dark:border-zinc-700 dark:text-zinc-300',
+            muted: 'bg-transparent border-zinc-300 dark:border-zinc-800 text-zinc-500 dark:text-zinc-500'
         }
     },
     defaultVariants: {

--- a/app/components/Tooltip.tsx
+++ b/app/components/Tooltip.tsx
@@ -17,11 +17,11 @@ export function Tooltip({ children, content, side = 'top' }: TooltipProps) {
                 <TooltipPrimitive.Portal>
                     <TooltipPrimitive.Content
                         side={side}
-                        className="z-50 rounded-lg bg-zinc-900 px-3 py-1.5 text-sm text-zinc-50 shadow-lg border border-zinc-700"
+                        className="z-50 bg-black px-3 py-1.5 font-mono text-xs uppercase tracking-[0.1em] text-white border-2 border-white"
                         sideOffset={4}
                     >
                         {content}
-                        <TooltipPrimitive.Arrow className="fill-zinc-900" />
+                        <TooltipPrimitive.Arrow className="fill-black" />
                     </TooltipPrimitive.Content>
                 </TooltipPrimitive.Portal>
             </TooltipPrimitive.Root>

--- a/app/components/Tooltip.tsx
+++ b/app/components/Tooltip.tsx
@@ -17,11 +17,11 @@ export function Tooltip({ children, content, side = 'top' }: TooltipProps) {
                 <TooltipPrimitive.Portal>
                     <TooltipPrimitive.Content
                         side={side}
-                        className="z-50 bg-black px-3 py-1.5 font-mono text-xs uppercase tracking-[0.1em] text-white border-2 border-white"
+                        className="z-50 rounded-lg bg-zinc-900 px-3 py-1.5 text-xs font-medium text-zinc-50 border border-zinc-700 shadow-lg"
                         sideOffset={4}
                     >
                         {content}
-                        <TooltipPrimitive.Arrow className="fill-black" />
+                        <TooltipPrimitive.Arrow className="fill-zinc-900" />
                     </TooltipPrimitive.Content>
                 </TooltipPrimitive.Portal>
             </TooltipPrimitive.Root>

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -1,7 +1,7 @@
 export enum BorderStyles {
-    DEFAULT = 'border border-zinc-300 dark:border-zinc-700',
-    BOTTOM = 'border-b border-b-zinc-300 dark:border-b-zinc-700',
-    TOP = 'border-t border-t-zinc-300 dark:border-t-zinc-700'
+    DEFAULT = 'border-2 border-black dark:border-zinc-200',
+    BOTTOM = 'border-b-2 border-b-black dark:border-b-zinc-200',
+    TOP = 'border-t-2 border-t-black dark:border-t-zinc-200'
 }
 
 export enum ContentStyles {

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -1,7 +1,7 @@
 export enum BorderStyles {
-    DEFAULT = 'border-2 border-black dark:border-zinc-200',
-    BOTTOM = 'border-b-2 border-b-black dark:border-b-zinc-200',
-    TOP = 'border-t-2 border-t-black dark:border-t-zinc-200'
+    DEFAULT = 'border border-zinc-200 dark:border-zinc-800',
+    BOTTOM = 'border-b border-b-zinc-200 dark:border-b-zinc-800',
+    TOP = 'border-t border-t-zinc-200 dark:border-t-zinc-800'
 }
 
 export enum ContentStyles {

--- a/app/content/data/service-offers.ts
+++ b/app/content/data/service-offers.ts
@@ -17,189 +17,380 @@ export interface ServiceOffer {
     slug: string;
     title: string;
     shortTitle: string;
+    kind: 'project' | 'retainer';
     tagline: string;
     seoDescription: string;
-    startingPrice: string;
     proofLine: string;
     idealFor: string[];
     deliverables: string[];
     scopeExamples: ServiceScopeExample[];
+    /** Heading override for the scope examples section. Defaults to "What an engagement looks like". */
+    scopeHeading?: string;
     process: ServiceProcessStep[];
+    /** Heading override for the process section. Defaults to "How it works". */
+    processHeading?: string;
     caseStudies: string[];
     faq: ServiceFaq[];
 }
 
+/** Old offer slugs that should permanently redirect after the 2026 reposition. */
+export const LEGACY_SERVICE_REDIRECTS: Record<string, string> = {
+    'cli-tools': '/services',
+    'contentful-sites': '/services/marketing-sites'
+};
+
 export const serviceOffers: ServiceOffer[] = [
     {
-        slug: 'cli-tools',
-        title: 'Custom CLI tools for agencies and product teams',
-        shortTitle: 'CLI tools',
-        tagline: 'Replace your team\'s graveyard of bash scripts with a single TypeScript CLI that ships as a standalone binary.',
+        slug: 'marketing-sites',
+        title: 'Marketing sites your team can actually edit',
+        shortTitle: 'Marketing sites',
+        kind: 'project',
+        tagline:
+            'A fast, well-built marketing site your team updates without filing a ticket. Designed and shipped in weeks, not quarters.',
         seoDescription:
-            'Custom CLI tool development for agencies and product teams. TypeScript, Bun, standalone binaries. Scaffolding, deploys, onboarding automation. Starting at $2,500.',
-        startingPrice: '$2,500',
-        proofLine: 'Based on buncli, my production template for Bun-based CLIs.',
+            'Marketing site design and development by Seth Davis. Fast, editable sites on React Router 7 with the CMS that fits your team. Book a free scope call.',
+        proofLine:
+            'Recent builds: the Cray Networks rebrand and the Virtruv brand and site.',
         idealFor: [
-            'Agencies that spin up new client projects and want every project scaffolded the same way',
-            'Product teams whose deploy, release, or onboarding steps live in a README nobody follows',
-            'Founders who need an internal tool for non-engineers (ops, support, finance) without building a full web app',
-            'Teams that currently rely on bash scripts, Makefiles, or one-off Python utilities nobody maintains'
+            'Teams whose copy changes wait on an engineer with better things to do',
+            'Companies outgrowing WordPress or Webflow and tired of fighting the page builder',
+            'Founders launching a product who need a credible site before the announcement date',
+            'Marketing teams that want Lighthouse scores they can show to whoever asks'
         ],
         deliverables: [
-            'A TypeScript CLI with your commands, options, and interactive prompts',
-            'Standalone binaries for macOS, Linux, and Windows (no runtime required on the target machine)',
-            'GitHub Actions release workflow that publishes binaries on each tag',
-            'Documented commands and a `--help` surface that reads like a product',
-            'A test harness so future commands have a pattern to follow',
-            'Handoff walkthrough and a written runbook for extending the CLI'
+            'A designed, responsive marketing site built on React Router 7',
+            'The CMS that fits your team (Contentful, Sanity, or plain MDX), wired with typed content queries',
+            'An editing workflow your team learns in one walkthrough, with preview before publish',
+            'SEO baseline: metadata, Open Graph, sitemap, structured data where it earns its place',
+            'Deploys with preview environments, so every change is reviewable at a URL',
+            'A build process that uses AI where it speeds things up, with every line reviewed by me before it ships'
         ],
         scopeExamples: [
             {
-                name: 'Agency project scaffolder',
+                name: 'Marketing site and blog',
                 description:
-                    'One command to scaffold a new client project from your standard stack: repo, CI, env files, design tokens, starter routes. Prompts for client name, stack variant, and deploy target.'
+                    'Home, product, pricing, about, and a blog the content team runs on their own. Launch-ready with analytics and SEO wired in.'
             },
             {
-                name: 'Guided deploy workflow',
+                name: 'Rebrand rollout',
                 description:
-                    'Wrap your deploy steps (migrations, smoke checks, cache purges, notifications) into a single interactive command with pre-flight validation and an audit log of who ran what.'
+                    'New identity applied to a live site: design tokens, typography, components, and pages rebuilt without breaking existing URLs or rankings.'
             },
             {
-                name: 'Ops lookup tool',
+                name: 'Page builder escape',
                 description:
-                    'A CLI for your support or ops team to look up customers, reset credentials, re-run failed jobs, and export audit snapshots without SQL access or a full admin UI.'
+                    'Migrate off WordPress or Webflow onto a stack your engineers respect and your editors still enjoy. Content moves over, URLs redirect cleanly.'
             }
         ],
         process: [
             {
                 step: 'Scope call (free)',
                 description:
-                    'A 30-minute call to map out the commands, users, and systems your CLI needs to touch. You leave with a written scope and fixed price.'
+                    '30 minutes. We look at what you have, what you need, and whether I am the right fit. You leave with a written scope either way.'
             },
             {
-                step: 'Prototype',
+                step: 'Design and content model',
                 description:
-                    'I ship a working CLI with 1-2 commands end-to-end so you can feel the shape of it before we expand.'
+                    'I design the key pages and model the content so editing feels obvious. You review at a real URL, not a PDF.'
             },
             {
-                step: 'Build + review',
+                step: 'Build with previews',
                 description:
-                    'The remaining commands, binary builds, CI release workflow, and docs. Regular demos so there are no surprises.'
+                    'The site comes together in preview deploys you can click through and comment on as it progresses.'
             },
             {
-                step: 'Handoff',
+                step: 'Launch and walkthrough',
                 description:
-                    'Walkthrough with your team, written runbook for adding new commands, and post-launch support included.'
+                    'DNS, redirects, analytics, and a recorded walkthrough so your team can edit confidently from day one.'
             }
         ],
-        caseStudies: ['buncli', 'tech-with-seth'],
+        caseStudies: ['craynetworks-rebrand', 'virtruv'],
         faq: [
             {
-                question: 'Why a CLI instead of a web app?',
+                question: 'Which CMS do you use?',
                 answer:
-                    'CLIs run in seconds, live next to the work (terminals, CI, IDEs), and can be version-controlled, code-reviewed, and scripted. For internal workflows with a small audience, a CLI is faster to build, cheaper to host (there\'s no server), and easier to trust than a one-off admin UI.'
+                    'Whichever fits your team. Contentful and Sanity are both excellent; for small sites, MDX in the repo is often simpler and free. The CMS is an implementation detail. The part that matters is that editing is easy and the output is fast.'
             },
             {
-                question: 'What if we\'re a Node shop, not a Bun shop?',
+                question: 'How do you use AI in the build?',
                 answer:
-                    'The CLI can target Node instead of Bun if you need it. Bun just makes the binary story dramatically simpler: a single executable your team can download and run without installing a runtime.'
+                    'For speed, not for slop. Agentic tooling accelerates scaffolding, content migration, and testing, which is why I can quote weeks instead of months. Every line of code and copy gets reviewed by me before it ships.'
             },
             {
-                question: 'How do updates work after handoff?',
+                question: 'What about SEO?',
                 answer:
-                    'Your repo, your CI, your binaries. The release workflow I set up means publishing a new version is a git tag. For ongoing work, I offer a monthly retainer, but most teams extend their CLI themselves using the patterns from the build.'
+                    'Every site ships with a real SEO baseline: server rendering, metadata, Open Graph images, sitemap, and structured data where it applies. Migrations include a redirect map so existing rankings carry over.'
             },
             {
-                question: 'Can you integrate with our existing APIs and auth?',
+                question: 'Where does it get hosted?',
                 answer:
-                    'Yes. The prototype phase is specifically for wiring up your real endpoints, auth (OAuth device flow, PATs, SSO-backed tokens, whatever you use), and any services the CLI needs to hit. The prompt patterns and error handling come from the template; the integration is tailored.'
+                    'Railway, Vercel, or Cloudflare, in your accounts so you own everything. Hosting for a typical marketing site runs a few dollars a month.'
             }
         ]
     },
     {
-        slug: 'contentful-sites',
-        title: 'Contentful-powered sites built on React Router 7',
-        shortTitle: 'Contentful sites',
+        slug: 'design-systems',
+        title: 'Design systems your team and your tools can use',
+        shortTitle: 'Design systems',
+        kind: 'project',
         tagline:
-            'Your content team gets a CMS they love. Your engineering team gets a typed, server-rendered React app they can actually maintain. I connect the two.',
+            'A component library with tokens, docs, and typed APIs so clear that both your engineers and their coding agents use it correctly.',
         seoDescription:
-            'Contentful integration with React Router 7: content modeling, live preview, server rendering, SEO, and a frontend your editors and engineers both want to use. Starting at $5,000.',
-        startingPrice: '$5,000',
-        proofLine: 'Built on React Router 7, the framework behind Shopify and sethdavis.tech.',
+            'Design system and component library development by Seth Davis. Design tokens, typed React components, docs, and agent-ready APIs. Book a free scope call.',
+        proofLine:
+            'I build and maintain Lone Star UI and Rivet UI, and helped establish the pattern library at Indeed.',
         idealFor: [
-            'Marketing teams stuck waiting on engineering for every content change',
-            'Companies that chose Contentful but still need a frontend to display it',
-            'Agencies delivering Contentful-backed sites to clients who need to self-serve content',
-            'Teams migrating from WordPress or Webflow to a headless architecture'
+            'Product teams whose UI is drifting: three button styles, four grays, no source of truth',
+            'Startups moving from "just ship it" to "we need this to look consistent"',
+            'Teams adopting AI coding tools that keep generating off-system UI',
+            'Design teams whose Figma library and the actual codebase stopped agreeing months ago'
         ],
         deliverables: [
-            'A React Router 7 app wired to your Contentful space with typed content queries',
-            'Content model design (or restructuring of your existing space) for clean editorial workflows',
-            'Contentful live preview so editors see changes before they publish',
-            'Server-side rendering with stale-while-revalidate caching for fast page loads',
-            'SEO baseline: meta, OpenGraph, Twitter cards, canonical URLs, XML sitemap, robots.txt',
-            'Deploy to Railway, Vercel, or Cloudflare with preview environments and webhook-triggered rebuilds'
+            'A token system (color, type, spacing) in OKLCH with light and dark modes from day one',
+            'Typed React components with variant-driven APIs, built on accessible primitives',
+            'Component documentation with live examples your team actually references',
+            'Agent-ready conventions: props and patterns predictable enough that coding agents produce on-system UI',
+            'Accessibility built in: WCAG AA contrast, keyboard navigation, focus management',
+            'An adoption plan and migration path for the UI you already have'
         ],
         scopeExamples: [
             {
-                name: 'Marketing site + blog',
+                name: 'System from scratch',
                 description:
-                    'Landing pages, blog, team bios, and case studies. Editors manage everything in Contentful. The frontend is fast, accessible, and SEO-ready without engineering involvement for content changes.'
+                    'Tokens, core components, and docs for a product that has design debt but no system. Scoped to the components you use, not a 50-component wishlist.'
             },
             {
-                name: 'Docs or knowledge base',
+                name: 'Brand-to-system translation',
                 description:
-                    'Structured documentation site with sidebar navigation, search, and versioning. Content lives in Contentful so non-engineers can update docs without touching code or markdown.'
+                    'Your brand guidelines turned into a working token system and themed component set, so the brand survives contact with the codebase.'
             },
             {
-                name: 'WordPress or Webflow migration',
+                name: 'System rescue',
                 description:
-                    'Move your existing content into Contentful and build a React Router 7 frontend that matches (or improves on) your current site. Redirects, SEO equity, and asset migration included.'
+                    'An existing library that nobody trusts gets audited, consolidated, and documented until it is the easiest way to build UI again.'
             }
         ],
         process: [
             {
                 step: 'Scope call (free)',
                 description:
-                    'We walk through your content, your team, and what the site needs to do. You leave with a written scope and a fixed price.'
+                    'We look at your current UI, where it drifts, and what a right-sized system looks like for your team.'
             },
             {
-                step: 'Content modeling',
+                step: 'Audit and tokens',
                 description:
-                    'I design (or restructure) your Contentful content types, validations, and editorial experience so your team can publish confidently.'
+                    'I inventory what exists, define the token system, and get agreement on the foundations before any components are built.'
             },
             {
-                step: 'Build + review',
+                step: 'Components and docs',
                 description:
-                    'Routes, components, live preview, caching, and SEO. Preview deploys on every push so you see progress throughout.'
+                    'Core components land in prioritized batches with documentation, so your team starts using the system before the engagement ends.'
             },
             {
-                step: 'Launch + handoff',
+                step: 'Adoption handoff',
                 description:
-                    'Production deploy, webhooks wired, editor walkthrough, and written documentation. Post-launch support included.'
+                    'Migration guide, contribution conventions, and a working session with your engineers so the system keeps growing without me.'
             }
         ],
-        caseStudies: ['tech-with-seth'],
+        caseStudies: ['lone-star-ui', 'craynetworks-rebrand'],
         faq: [
             {
-                question: 'Why React Router 7 and not Next.js?',
+                question: 'What stack do you build on?',
                 answer:
-                    'React Router 7 gives you server rendering, route-level data loading, and prerendering without the complexity and vendor lock-in of Next.js. It deploys anywhere (Railway, Vercel, Cloudflare, a Docker container) and the entire data flow is typed end-to-end.'
+                    'React, TypeScript, Tailwind CSS, and CVA for variants, on top of accessible primitives like Base UI. If your team is on something else, the token layer still transfers; we talk about it on the scope call.'
             },
             {
-                question: 'We already have a Contentful space. Can you work with it?',
+                question: 'What does "agent-ready" actually mean?',
                 answer:
-                    'Yes. I\'ll audit your existing content types and either build on them or propose changes if the current structure is making editorial work harder than it should be. No need to start from scratch.'
+                    'Typed, variant-driven component APIs with consistent naming and documented conventions. When the patterns are predictable, coding agents (and new hires) produce UI that looks like it belongs. Teams using AI tooling get compounding value from this.'
             },
             {
-                question: 'How does live preview work?',
+                question: 'Do you work with our existing Figma library?',
                 answer:
-                    'Contentful\'s live preview SDK lets editors see draft changes in the actual frontend before publishing. I wire this up so your preview environment shows real-time updates as editors type, not a separate "preview mode" that looks nothing like the live site.'
+                    'Yes. If you have design files, I translate them into tokens and components and flag where the designs disagree with themselves. If you do not, I can define the visual foundations as part of the work.'
             },
             {
-                question: 'What about images and media?',
+                question: 'How do you keep the system from dying after handoff?',
                 answer:
-                    'Contentful\'s built-in asset CDN handles responsive images, format conversion, and quality optimization out of the box. If you have heavier media needs (video, AI-generated imagery), I can layer on Cloudinary as part of the build.'
+                    'The handoff includes contribution conventions, docs, and a working session with your team. Systems die when adding to them is harder than going rogue, so the engagement optimizes for the system being the easy path.'
+            }
+        ]
+    },
+    {
+        slug: 'ai-prototyping',
+        title: 'AI product prototypes built on production patterns',
+        shortTitle: 'AI prototyping',
+        kind: 'project',
+        tagline:
+            'A working AI prototype in weeks: agents, tool calling, real chat UX. Validate the idea before you commit a roadmap to it.',
+        seoDescription:
+            'AI product prototyping by Seth Davis. Working prototypes with agents, tool calling, and designed chat UX, built on production patterns. Book a free scope call.',
+        proofLine:
+            'Built on patterns from Iridium, my AI app starter kit, and Sprocket, a 12-agent personal assistant.',
+        idealFor: [
+            'Founders with an AI product idea who need something real to show users or investors',
+            'Product teams who need to know if an agent workflow actually fits before staffing it',
+            'Companies whose AI demo is a slide deck and needs to become a working thing',
+            'Teams that tried building on raw API calls and hit a wall on tool calling or state'
+        ],
+        deliverables: [
+            'A working prototype users can touch: real model calls, real data, deployed at a URL',
+            'Agent and tool-calling architecture that maps to how the production version would work',
+            'Chat and generative UI that feels designed, not dumped on screen',
+            'Model and provider recommendation based on your workload, with costs estimated',
+            'Clean TypeScript codebase your team can extend into production',
+            'A written readout: what the prototype proved, what it did not, and what production takes'
+        ],
+        scopeExamples: [
+            {
+                name: 'Agent workflow prototype',
+                description:
+                    'An agent that does a real job in your domain with tool calling against your actual APIs, so you can judge usefulness instead of guessing.'
+            },
+            {
+                name: 'AI feature inside your product',
+                description:
+                    'A designed, working AI feature (assistant, summarization, generation) integrated against a copy of your real product surface.'
+            },
+            {
+                name: 'Investor-ready demo',
+                description:
+                    'A polished, deployed demo that shows the core magic reliably. Built honest: the readout is clear about what is real and what is staged.'
+            }
+        ],
+        process: [
+            {
+                step: 'Scope call (free)',
+                description:
+                    'We define the one question the prototype must answer and the smallest build that answers it.'
+            },
+            {
+                step: 'Architecture sketch',
+                description:
+                    'Agents, tools, models, and data flows on one page. You know what is being built and why before the build starts.'
+            },
+            {
+                step: 'Build in weekly demos',
+                description:
+                    'The prototype grows in weekly deployed checkpoints. You steer while it is cheap to steer.'
+            },
+            {
+                step: 'Readout and handoff',
+                description:
+                    'Working prototype, the codebase, and a straight readout on what production requires. No demo theater.'
+            }
+        ],
+        caseStudies: ['iridium', 'sprocket', 'ai-maniacs'],
+        faq: [
+            {
+                question: 'Prototype or production?',
+                answer:
+                    'Prototype, built on production patterns. It is real code with real architecture, so nothing has to be thrown away, but the goal is answering "should we build this" in weeks rather than shipping to thousands of users.'
+            },
+            {
+                question: 'Which models and providers do you use?',
+                answer:
+                    'Claude is my default for agentic work and tool calling. The recommendation depends on your workload, latency, and budget, and the prototype makes switching providers cheap to test.'
+            },
+            {
+                question: 'What happens to the code?',
+                answer:
+                    'It is yours. Clean TypeScript in your repos, documented well enough that your team or a future contractor extends it without archaeology.'
+            },
+            {
+                question: 'What about our data?',
+                answer:
+                    'Prototypes run in your accounts against the data you choose to expose. Nothing gets used to train anything, and provider data policies are part of the model recommendation.'
+            }
+        ]
+    },
+    {
+        slug: 'fractional-design-technologist',
+        title: 'A fractional design technologist on your team',
+        shortTitle: 'Fractional design technologist',
+        kind: 'retainer',
+        tagline:
+            'A senior design engineer embedded with your team a set number of days per week. Design system stewardship, frontend quality, and AI tooling adoption without a full-time hire.',
+        seoDescription:
+            'Fractional design technologist retainer with Seth Davis. Embedded design engineering: design systems, frontend quality, AI tooling adoption. Book a free scope call.',
+        proofLine:
+            'Nine years doing this work inside product teams, most recently as a Senior Design Technologist at Gartner and Indeed.',
+        idealFor: [
+            'Teams that need design engineering weekly but cannot justify a full-time hire yet',
+            'Startups whose product works but looks and feels a step behind the competition',
+            'Engineering teams adopting AI coding tools who want the output to stay on-brand and accessible',
+            'Design teams who need an engineer that speaks design fluently and closes the handoff gap'
+        ],
+        deliverables: [
+            'Set embedded days per week in your Slack, your standups, and your codebase',
+            'Design system stewardship: the tokens, components, and docs stay coherent as the product grows',
+            'Interface quality work: motion, polish, accessibility, and the details that usually get deprioritized',
+            'AI tooling adoption: conventions and reviews that keep agent-generated UI on-system',
+            'Design-to-engineering translation in critiques, planning, and reviews',
+            'A monthly written summary of what shipped and where quality is trending'
+        ],
+        scopeHeading: 'What I take off your plate',
+        scopeExamples: [
+            {
+                name: 'Design system stewardship',
+                description:
+                    'The component library stops rotting. New patterns get componentized, drift gets caught in review, docs stay current.'
+            },
+            {
+                name: 'Frontend quality ownership',
+                description:
+                    'Someone is finally accountable for how the product feels: interaction details, empty states, loading states, accessibility.'
+            },
+            {
+                name: 'AI tooling guardrails',
+                description:
+                    'Your team ships faster with coding agents while the UI stays consistent, because the conventions and reviews are in place.'
+            }
+        ],
+        processHeading: 'How the retainer works',
+        process: [
+            {
+                step: 'Scope call (free)',
+                description:
+                    'We figure out the days per week, the first priorities, and whether embedded is the right shape for what you need.'
+            },
+            {
+                step: 'Kickoff week',
+                description:
+                    'I get into the codebase, the design files, and the backlog, then propose a first-month plan you approve.'
+            },
+            {
+                step: 'Weekly rhythm',
+                description:
+                    'Set days per week of shipping, reviews, and pairing. Async the rest of the time for questions that cannot wait.'
+            },
+            {
+                step: 'Monthly review',
+                description:
+                    'A written summary of what shipped and a reset of priorities. The retainer is month to month; it continues because it is working.'
+            }
+        ],
+        caseStudies: ['sprocket', 'craynetworks-rebrand'],
+        faq: [
+            {
+                question: 'How many days per week?',
+                answer:
+                    'Typically one to three, fixed so your team can plan around them. We set the number on the scope call and can adjust it monthly.'
+            },
+            {
+                question: 'How is this different from hiring a contractor?',
+                answer:
+                    'A contractor takes tickets. This is embedded ownership of a lane (design systems, frontend quality, AI adoption) including the judgment calls, the reviews, and the parts nobody wrote a ticket for.'
+            },
+            {
+                question: 'What do you need access to?',
+                answer:
+                    'The repo, the design files, and your Slack. I work in your accounts and your tools, so everything stays yours if we stop.'
+            },
+            {
+                question: 'What are the terms?',
+                answer:
+                    'Month to month with a monthly review. No long lock-in: the arrangement continues because it is obviously worth it, not because a contract says so.'
             }
         ]
     }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -74,6 +74,19 @@ export function Layout({ children }: { children: React.ReactNode }) {
                     rel="preconnect"
                     href="https://res.cloudinary.com"
                 />
+                <link
+                    rel="preconnect"
+                    href="https://fonts.googleapis.com"
+                />
+                <link
+                    rel="preconnect"
+                    href="https://fonts.gstatic.com"
+                    crossOrigin="anonymous"
+                />
+                <link
+                    rel="stylesheet"
+                    href="https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,100..900;1,100..900&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap"
+                />
                 <Meta />
                 <Links />
             </head>

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -27,7 +27,7 @@ function Quote({ quote, author }: { quote: string; author: string }) {
         <blockquote className="border-l-4 border-primary-500 pl-6">
             <p className="mb-2 font-display text-xl md:text-2xl">{`"${quote}"`}</p>
             <footer>
-                <cite className="font-mono text-xs uppercase tracking-[0.2em] not-italic text-zinc-600 dark:text-zinc-400">
+                <cite className="text-xs font-medium tracking-wide not-italic text-zinc-600 dark:text-zinc-400">
                     &mdash; {author}
                 </cite>
             </footer>
@@ -95,11 +95,11 @@ export default function AboutRoute({ loaderData }: Route.ComponentProps) {
 
     return (
         <>
-            <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-10">
+            <div className="flex items-baseline justify-between border-b border-zinc-200 dark:border-zinc-800 pb-3 mb-10">
                 <Heading as="h1" className="mb-0">
                     About me
                 </Heading>
-                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                <span className="text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400">
                     The person
                 </span>
             </div>
@@ -174,7 +174,7 @@ export default function AboutRoute({ loaderData }: Route.ComponentProps) {
                     </div>
                 </>
             )}
-            <hr className="border-t-2 border-black dark:border-zinc-200 my-12" />
+            <hr className="border-t border-zinc-200 dark:border-zinc-800 my-12" />
             <section className="">
                 <Heading as="h2" className="mb-4">
                     Want to see it in action?
@@ -198,7 +198,7 @@ export default function AboutRoute({ loaderData }: Route.ComponentProps) {
                     </Linky>
                 </p>
             </section>
-            <hr className="border-t-2 border-black dark:border-zinc-200 my-12" />
+            <hr className="border-t border-zinc-200 dark:border-zinc-800 my-12" />
             <Heading as="h2" className="mb-8">
                 Motivation
             </Heading>

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -24,10 +24,12 @@ export function loader() {
 
 function Quote({ quote, author }: { quote: string; author: string }) {
     return (
-        <blockquote>
-            <p className="mb-2">{`"${quote}"`}</p>
+        <blockquote className="border-l-4 border-primary-500 pl-6">
+            <p className="mb-2 font-display text-xl md:text-2xl">{`"${quote}"`}</p>
             <footer>
-                <cite className="text-sm">&mdash; {author}</cite>
+                <cite className="font-mono text-xs uppercase tracking-[0.2em] not-italic text-zinc-600 dark:text-zinc-400">
+                    &mdash; {author}
+                </cite>
             </footer>
         </blockquote>
     );
@@ -81,7 +83,7 @@ function ValueCard({
             <Heading as="h3" size="4" className="mb-4">
                 {title}
             </Heading>
-            <p className="text-zinc-300">{description}</p>
+            <p className="text-zinc-700 dark:text-zinc-300">{description}</p>
         </Card>
     );
 }
@@ -93,9 +95,14 @@ export default function AboutRoute({ loaderData }: Route.ComponentProps) {
 
     return (
         <>
-            <Heading as="h1" className="mb-8">
-                About me
-            </Heading>
+            <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-10">
+                <Heading as="h1" className="mb-0">
+                    About me
+                </Heading>
+                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                    The person
+                </span>
+            </div>
             <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 mb-6 sm:mb-8">
                 <ul className="basis-1/2 space-y-4">
                     {leftFacts.map(function (fact) {
@@ -167,12 +174,12 @@ export default function AboutRoute({ loaderData }: Route.ComponentProps) {
                     </div>
                 </>
             )}
-            <hr className="border-zinc-500 my-12" />
+            <hr className="border-t-2 border-black dark:border-zinc-200 my-12" />
             <section className="">
                 <Heading as="h2" className="mb-4">
                     Want to see it in action?
                 </Heading>
-                <p className="text-zinc-300 mb-6">
+                <p className="text-zinc-700 dark:text-zinc-300 mb-6">
                     Check out projects where I put these values into practice,
                     or get in touch to discuss working together.
                 </p>
@@ -184,14 +191,14 @@ export default function AboutRoute({ loaderData }: Route.ComponentProps) {
                         Get in touch
                     </Button>
                 </div>
-                <p className="mt-6 text-zinc-400">
+                <p className="mt-6 text-zinc-600 dark:text-zinc-400">
                     Or email me directly at{' '}
                     <Linky href={`mailto:${CONTACT_EMAIL}`}>
                         {CONTACT_EMAIL}
                     </Linky>
                 </p>
             </section>
-            <hr className="border-zinc-500 my-12" />
+            <hr className="border-t-2 border-black dark:border-zinc-200 my-12" />
             <Heading as="h2" className="mb-8">
                 Motivation
             </Heading>

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -103,10 +103,13 @@ export default function ContactRoute() {
     return (
         <article className="max-w-3xl mx-auto space-y-12">
             <section>
+                <div className="border-b-2 border-black dark:border-zinc-200 pb-3 mb-6 font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                    Correspondence
+                </div>
                 <Heading as="h1" className="mb-4">
                     Get in touch
                 </Heading>
-                <p className="text-lg text-zinc-300 mb-8">
+                <p className="text-lg text-zinc-700 dark:text-zinc-300 mb-8">
                     Hiring, a project, or just want to compare notes? The fastest
                     way to reach me is email. Prefer a form? There's one below and
                     it lands straight in my inbox.
@@ -114,7 +117,7 @@ export default function ContactRoute() {
                 <div className="flex flex-col sm:flex-row sm:items-center gap-4">
                     <a
                         href={`mailto:${CONTACT_EMAIL}`}
-                        className="inline-flex items-center gap-2 rounded-lg bg-primary-500/15 hover:bg-primary-500/25 text-primary-300 hover:text-primary-200 transition-colors duration-200 px-4 py-3 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+                        className="inline-flex items-center gap-2 border-2 border-black dark:border-zinc-200 bg-primary-400 text-black px-4 py-3 font-mono text-sm uppercase tracking-[0.1em] font-semibold shadow-[4px_4px_0_0_var(--color-black)] dark:shadow-[4px_4px_0_0_var(--color-zinc-200)] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[2px_2px_0_0_var(--color-black)] dark:hover:shadow-[2px_2px_0_0_var(--color-zinc-200)] transition-[transform,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950"
                     >
                         <Mail className="size-5" />
                         {CONTACT_EMAIL}
@@ -134,13 +137,13 @@ export default function ContactRoute() {
 
             <section
                 id="message"
-                className="rounded-xl bg-gradient-to-br from-zinc-900 via-zinc-900 to-primary-950/40 border border-zinc-800 p-8 md:p-10"
+                className="border-2 border-black dark:border-zinc-200 p-8 md:p-10"
             >
                 <div className="max-w-xl mb-6">
                     <Heading as="h2" size="3" className="mb-3">
                         Send a message
                     </Heading>
-                    <p className="text-zinc-300">
+                    <p className="text-zinc-700 dark:text-zinc-300">
                         Tell me a bit about what you have in mind. I read every
                         message and reply within one business day.
                     </p>

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -103,9 +103,6 @@ export default function ContactRoute() {
     return (
         <article className="max-w-3xl mx-auto space-y-12">
             <section>
-                <div className="border-b-2 border-black dark:border-zinc-200 pb-3 mb-6 font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
-                    Correspondence
-                </div>
                 <Heading as="h1" className="mb-4">
                     Get in touch
                 </Heading>
@@ -117,7 +114,7 @@ export default function ContactRoute() {
                 <div className="flex flex-col sm:flex-row sm:items-center gap-4">
                     <a
                         href={`mailto:${CONTACT_EMAIL}`}
-                        className="inline-flex items-center gap-2 border-2 border-black dark:border-zinc-200 bg-primary-400 text-black px-4 py-3 font-mono text-sm uppercase tracking-[0.1em] font-semibold shadow-[4px_4px_0_0_var(--color-black)] dark:shadow-[4px_4px_0_0_var(--color-zinc-200)] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[2px_2px_0_0_var(--color-black)] dark:hover:shadow-[2px_2px_0_0_var(--color-zinc-200)] transition-[transform,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950"
+                        className="inline-flex items-center gap-2 rounded-lg bg-primary-400 hover:bg-primary-300 text-black px-4 py-3 text-sm font-medium shadow-sm transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950"
                     >
                         <Mail className="size-5" />
                         {CONTACT_EMAIL}
@@ -137,7 +134,7 @@ export default function ContactRoute() {
 
             <section
                 id="message"
-                className="border-2 border-black dark:border-zinc-200 p-8 md:p-10"
+                className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/60 p-8 md:p-10"
             >
                 <div className="max-w-xl mb-6">
                     <Heading as="h2" size="3" className="mb-3">

--- a/app/routes/design-technologist.tsx
+++ b/app/routes/design-technologist.tsx
@@ -95,7 +95,7 @@ export default function DesignTechnologistRoute() {
             <Heading as="h1" className="mb-4">
                 What is a Design Technologist?
             </Heading>
-            <p className="text-lg text-zinc-300 mb-12 max-w-2xl">
+            <p className="text-lg text-zinc-700 dark:text-zinc-300 mb-12 max-w-2xl">
                 A Design Technologist is an engineer who thinks like a designer.
                 They operate at the intersection of design and code, eliminating
                 the handoff gap that exists between most design and engineering
@@ -138,18 +138,18 @@ export default function DesignTechnologistRoute() {
                                 key={role.title}
                                 className={
                                     role.highlighted
-                                        ? 'ring-2 ring-primary-500 dark:ring-primary-400'
+                                        ? 'border-primary-600 dark:border-primary-400 shadow-[6px_6px_0_0_var(--color-primary-600)] dark:shadow-[6px_6px_0_0_var(--color-primary-400)]'
                                         : ''
                                 }
                             >
                                 <Heading as="h3" size="4" className="mb-3">
                                     {role.title}
                                 </Heading>
-                                <p className="text-sm text-zinc-400 mb-2">
+                                <p className="font-mono text-xs uppercase tracking-[0.2em] text-zinc-500 dark:text-zinc-400 mb-2">
                                     Focus
                                 </p>
                                 <p className="mb-4">{role.focus}</p>
-                                <p className="text-sm text-zinc-400 mb-2">
+                                <p className="font-mono text-xs uppercase tracking-[0.2em] text-zinc-500 dark:text-zinc-400 mb-2">
                                     Primary output
                                 </p>
                                 <p>{role.output}</p>
@@ -181,7 +181,7 @@ export default function DesignTechnologistRoute() {
                                                 key={item}
                                                 className="flex items-start gap-2"
                                             >
-                                                <span className="text-primary-500 mt-1.5 block w-1.5 h-1.5 rounded-full bg-current shrink-0" />
+                                                <span className="text-primary-600 dark:text-primary-400 mt-2 block w-2 h-2 bg-current shrink-0" />
                                                 <span>{item}</span>
                                             </li>
                                         );
@@ -208,7 +208,7 @@ export default function DesignTechnologistRoute() {
                                 >
                                     {item.title}
                                 </Heading>
-                                <p className="text-zinc-300">
+                                <p className="text-zinc-700 dark:text-zinc-300">
                                     {item.description}
                                 </p>
                             </Card>
@@ -223,7 +223,7 @@ export default function DesignTechnologistRoute() {
                 </Heading>
                 <div className="space-y-4 max-w-2xl">
                     <p>
-                        <strong className="text-white">
+                        <strong className="text-black dark:text-white">
                             Design systems are infrastructure.
                         </strong>{' '}
                         Every serious product team maintains a component library.
@@ -231,7 +231,7 @@ export default function DesignTechnologistRoute() {
                         engineering rigor in that system.
                     </p>
                     <p>
-                        <strong className="text-white">
+                        <strong className="text-black dark:text-white">
                             AI is creating new interface paradigms.
                         </strong>{' '}
                         Generative UI, conversational interfaces, and
@@ -241,7 +241,7 @@ export default function DesignTechnologistRoute() {
                         simultaneously.
                     </p>
                     <p>
-                        <strong className="text-white">
+                        <strong className="text-black dark:text-white">
                             Speed of iteration is a competitive advantage.
                         </strong>{' '}
                         Teams that go from concept to working prototype in hours
@@ -249,7 +249,7 @@ export default function DesignTechnologistRoute() {
                         compresses that cycle dramatically.
                     </p>
                     <p>
-                        <strong className="text-white">
+                        <strong className="text-black dark:text-white">
                             The last 10% of UI quality is disproportionately
                             valuable.
                         </strong>{' '}
@@ -260,13 +260,13 @@ export default function DesignTechnologistRoute() {
                 </div>
             </section>
 
-            <hr className="border-zinc-500 my-12" />
+            <hr className="border-t-2 border-black dark:border-zinc-200 my-12" />
 
             <section>
                 <Heading as="h2" className="mb-4">
                     See it in practice
                 </Heading>
-                <p className="text-zinc-300 mb-6">
+                <p className="text-zinc-700 dark:text-zinc-300 mb-6">
                     Check out my work building design systems, creative tooling,
                     and generative interfaces.
                 </p>

--- a/app/routes/design-technologist.tsx
+++ b/app/routes/design-technologist.tsx
@@ -138,18 +138,18 @@ export default function DesignTechnologistRoute() {
                                 key={role.title}
                                 className={
                                     role.highlighted
-                                        ? 'border-primary-600 dark:border-primary-400 shadow-[6px_6px_0_0_var(--color-primary-600)] dark:shadow-[6px_6px_0_0_var(--color-primary-400)]'
+                                        ? 'border-primary-600 dark:border-primary-400 shadow-lg shadow-primary-900/20'
                                         : ''
                                 }
                             >
                                 <Heading as="h3" size="4" className="mb-3">
                                     {role.title}
                                 </Heading>
-                                <p className="font-mono text-xs uppercase tracking-[0.2em] text-zinc-500 dark:text-zinc-400 mb-2">
+                                <p className="text-xs font-medium tracking-wide text-zinc-500 dark:text-zinc-400 mb-2">
                                     Focus
                                 </p>
                                 <p className="mb-4">{role.focus}</p>
-                                <p className="font-mono text-xs uppercase tracking-[0.2em] text-zinc-500 dark:text-zinc-400 mb-2">
+                                <p className="text-xs font-medium tracking-wide text-zinc-500 dark:text-zinc-400 mb-2">
                                     Primary output
                                 </p>
                                 <p>{role.output}</p>
@@ -260,7 +260,7 @@ export default function DesignTechnologistRoute() {
                 </div>
             </section>
 
-            <hr className="border-t-2 border-black dark:border-zinc-200 my-12" />
+            <hr className="border-t border-zinc-200 dark:border-zinc-800 my-12" />
 
             <section>
                 <Heading as="h2" className="mb-4">

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -54,13 +54,13 @@ export default function Home({ loaderData }: Route.ComponentProps) {
     return (
         <>
             <HomeSection className="md:py-16">
-                <div className="flex items-center justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-8 font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                <div className="flex items-center justify-between border-b border-zinc-200 dark:border-zinc-800 pb-3 mb-8 text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400">
                     <span>Design Technologist</span>
-                    <span aria-hidden="true">Austin, TX — Vol. 01</span>
+                    <span aria-hidden="true">Austin, TX</span>
                 </div>
                 <Heading
                     as="h1"
-                    className="text-[clamp(4rem,14vw,11rem)] md:text-[clamp(4rem,14vw,11rem)] leading-[0.85] mb-8 tracking-tight"
+                    className="text-[clamp(3.5rem,10vw,8rem)] md:text-[clamp(3.5rem,10vw,8rem)] leading-[0.95] mb-8 tracking-tight"
                 >
                     Seth
                     <br />
@@ -69,7 +69,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                     </span>
                 </Heading>
                 <div className="grid md:grid-cols-12 gap-8 items-start">
-                    <div className="md:col-span-7 border-t-2 border-black dark:border-zinc-200 pt-6">
+                    <div className="md:col-span-7 border-t border-zinc-200 dark:border-zinc-800 pt-6">
                         <p className="text-xl md:text-2xl font-medium max-w-2xl mb-4 text-zinc-800 dark:text-zinc-200">
                             I help product teams ship better interfaces
                             faster, through design systems, AI tooling, and
@@ -90,7 +90,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                             </Button>
                         </div>
                     </div>
-                    <div className="hidden md:block md:col-span-5 border-t-2 border-black dark:border-zinc-200 pt-6 font-mono text-xs uppercase tracking-[0.2em] text-zinc-600 dark:text-zinc-400 space-y-2">
+                    <div className="hidden md:block md:col-span-5 border-t border-zinc-200 dark:border-zinc-800 pt-6 text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400 space-y-2">
                         <p>Design systems</p>
                         <p>AI tooling</p>
                         <p>Front-end engineering</p>
@@ -98,29 +98,26 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                 </div>
             </HomeSection>
             <HomeSection>
-                <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-8">
+                <div className="flex items-baseline justify-between border-b border-zinc-200 dark:border-zinc-800 pb-3 mb-8">
                     <Heading className="mb-0">Featured projects</Heading>
-                    <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
-                        02
-                    </span>
                 </div>
                 <div className="grid grid-cols-1 gap-6">
                     {/* Hero project: full width acid slab */}
-                    <Card className="p-0 grid overflow-hidden bg-primary-400 dark:bg-primary-400 text-black dark:text-black border-black dark:border-black shadow-[8px_8px_0_0_var(--color-black)] dark:shadow-[8px_8px_0_0_var(--color-zinc-200)]">
+                    <Card className="p-0 grid overflow-hidden bg-primary-500/10 dark:bg-primary-500/10 border-primary-500/40">
                         <div className="col-start-1 row-start-1 p-8 md:p-10 flex flex-col">
-                            <span className="font-mono text-xs uppercase tracking-[0.25em] mb-3">
-                                No. 001 — Flagship
+                            <span className="text-xs font-medium tracking-wide text-primary-700 dark:text-primary-300 mb-3">
+                                Flagship
                             </span>
-                            <Heading className="text-black dark:text-black text-4xl md:text-5xl">
+                            <Heading className="text-4xl md:text-5xl">
                                 Iridium
                             </Heading>
-                            <p className="mb-8 max-w-2xl text-lg font-medium">
+                            <p className="mb-8 max-w-2xl text-lg text-zinc-700 dark:text-zinc-300">
                                 Full-stack AI app starter kit with TypeScript,
                                 React Router, Better Auth, and Anthropic. Ship
                                 faster, not from scratch.
                             </p>
                             <Button
-                                className="self-start bg-black text-primary-400 border-black shadow-[4px_4px_0_0_var(--color-primary-900)] dark:border-black dark:shadow-[4px_4px_0_0_var(--color-primary-900)]"
+                                className="self-start"
                                 color="primary"
                                 size="lg"
                                 to="/work/iridium"
@@ -133,8 +130,8 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                         <Card className="p-0 grid overflow-hidden">
                             <div className="col-start-1 row-start-1 p-8 flex flex-col">
-                                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400 mb-3">
-                                    No. 002 — Open Source
+                                <span className="text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400 mb-3">
+                                    Open Source
                                 </span>
                                 <Heading>Lone Star UI</Heading>
                                 <p className="mb-8 text-zinc-700 dark:text-zinc-300">
@@ -156,8 +153,8 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                         </Card>
                         <Card className="p-0 grid overflow-hidden">
                             <div className="col-start-1 row-start-1 p-8 flex flex-col">
-                                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400 mb-3">
-                                    No. 003 — Learning
+                                <span className="text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400 mb-3">
+                                    Learning
                                 </span>
                                 <Heading>AI Maniacs</Heading>
                                 <p className="mb-8 text-zinc-700 dark:text-zinc-300">
@@ -178,8 +175,8 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                         </Card>
                         <Card className="p-0 grid overflow-hidden">
                             <div className="col-start-1 row-start-1 p-8 flex flex-col">
-                                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400 mb-3">
-                                    No. 004 — Product
+                                <span className="text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400 mb-3">
+                                    Product
                                 </span>
                                 <Heading>Prompt Suite</Heading>
                                 <p className="mb-8 text-zinc-700 dark:text-zinc-300">
@@ -203,7 +200,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
             </HomeSection>
             {decks.length > 0 && (
                 <HomeSection>
-                    <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-8">
+                    <div className="flex items-baseline justify-between border-b border-zinc-200 dark:border-zinc-800 pb-3 mb-8">
                         <Heading className="mb-0">Recent slides</Heading>
                         <Linky to="/slides" className="text-sm">
                             All slides →
@@ -216,20 +213,20 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                                 to={`/slides/${deck.slug}`}
                                 className="block no-underline hover:bg-transparent hover:text-current dark:hover:text-current"
                             >
-                                <Card className="h-full p-0 grid overflow-hidden group hover:bg-primary-400 dark:hover:bg-primary-400 hover:text-black dark:hover:text-black transition-colors duration-150">
+                                <Card className="h-full p-0 grid overflow-hidden group transition-colors duration-200 hover:border-primary-500/60">
                                     <div className="col-start-1 row-start-1 p-8 flex flex-col">
-                                        <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400 group-hover:text-black mb-3">
+                                        <span className="text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400 mb-3">
                                             Deck
                                         </span>
-                                        <Heading className="group-hover:text-black dark:group-hover:text-black">
+                                        <Heading>
                                             {deck.title}
                                         </Heading>
                                         {deck.description && (
-                                            <p className="mb-6 text-zinc-700 dark:text-zinc-300 group-hover:text-black">
+                                            <p className="mb-6 text-zinc-700 dark:text-zinc-300">
                                                 {deck.description}
                                             </p>
                                         )}
-                                        <span className="mt-auto text-xs font-mono uppercase tracking-[0.15em] text-zinc-500 group-hover:text-black">
+                                        <span className="mt-auto text-xs text-zinc-500">
                                             {deck.slideCount} slide
                                             {deck.slideCount === 1 ? '' : 's'}
                                         </span>
@@ -241,11 +238,8 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                 </HomeSection>
             )}
             <HomeSection>
-                <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-8">
+                <div className="flex items-baseline justify-between border-b border-zinc-200 dark:border-zinc-800 pb-3 mb-8">
                     <Heading className="mb-0">Socials</Heading>
-                    <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
-                        04
-                    </span>
                 </div>
                 <div className="flex gap-8">
                     <Linky

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -54,30 +54,34 @@ export default function Home({ loaderData }: Route.ComponentProps) {
     return (
         <>
             <HomeSection className="md:py-16">
-                <div className="flex items-start gap-6">
-                    <div className="hidden md:block w-1 self-stretch bg-primary-500 rounded-full" />
-                    <div>
-                        <span className="text-sm uppercase tracking-widest text-zinc-500 dark:text-zinc-400 mb-2 block">
-                            Design Technologist
-                        </span>
-                        <Heading
-                            as="h1"
-                            className="text-7xl md:text-9xl font-black mb-6"
-                        >
-                            Seth Davis
-                        </Heading>
-                        <p className="text-lg md:text-2xl font-medium max-w-2xl mb-4 text-zinc-300">
+                <div className="flex items-center justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-8 font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                    <span>Design Technologist</span>
+                    <span aria-hidden="true">Austin, TX — Vol. 01</span>
+                </div>
+                <Heading
+                    as="h1"
+                    className="text-[clamp(4rem,14vw,11rem)] md:text-[clamp(4rem,14vw,11rem)] leading-[0.85] mb-8 tracking-tight"
+                >
+                    Seth
+                    <br />
+                    <span className="italic text-primary-600 dark:text-primary-400">
+                        Davis
+                    </span>
+                </Heading>
+                <div className="grid md:grid-cols-12 gap-8 items-start">
+                    <div className="md:col-span-7 border-t-2 border-black dark:border-zinc-200 pt-6">
+                        <p className="text-xl md:text-2xl font-medium max-w-2xl mb-4 text-zinc-800 dark:text-zinc-200">
                             I help product teams ship better interfaces
                             faster, through design systems, AI tooling, and
                             front-end engineering.
                         </p>
-                        <p className="mb-10 text-zinc-400">
+                        <p className="mb-10 text-zinc-600 dark:text-zinc-400">
                             Open to new engagements as a{' '}
                             <Linky to="/design-technologist">
                                 {ContentStyles.CURRENT_JOB_TITLE}
                             </Linky>
                         </p>
-                        <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
+                        <div className="flex flex-col sm:flex-row gap-4">
                             <Button size="lg" to="/work">
                                 See my work
                             </Button>
@@ -86,27 +90,37 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                             </Button>
                         </div>
                     </div>
+                    <div className="hidden md:block md:col-span-5 border-t-2 border-black dark:border-zinc-200 pt-6 font-mono text-xs uppercase tracking-[0.2em] text-zinc-600 dark:text-zinc-400 space-y-2">
+                        <p>Design systems</p>
+                        <p>AI tooling</p>
+                        <p>Front-end engineering</p>
+                    </div>
                 </div>
             </HomeSection>
             <HomeSection>
-                <Heading>Featured projects</Heading>
+                <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-8">
+                    <Heading className="mb-0">Featured projects</Heading>
+                    <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                        02
+                    </span>
+                </div>
                 <div className="grid grid-cols-1 gap-6">
-                    {/* Hero project: full width */}
-                    <Card className="p-0 grid overflow-hidden border border-primary-800/40 bg-zinc-900">
-                        <div className="col-start-1 row-start-1 p-8 md:p-10 text-white flex flex-col">
-                            <span className="text-xs uppercase tracking-widest text-primary-400 mb-3">
-                                Flagship
+                    {/* Hero project: full width acid slab */}
+                    <Card className="p-0 grid overflow-hidden bg-primary-400 dark:bg-primary-400 text-black dark:text-black border-black dark:border-black shadow-[8px_8px_0_0_var(--color-black)] dark:shadow-[8px_8px_0_0_var(--color-zinc-200)]">
+                        <div className="col-start-1 row-start-1 p-8 md:p-10 flex flex-col">
+                            <span className="font-mono text-xs uppercase tracking-[0.25em] mb-3">
+                                No. 001 — Flagship
                             </span>
-                            <Heading className="text-white text-3xl md:text-4xl">
+                            <Heading className="text-black dark:text-black text-4xl md:text-5xl">
                                 Iridium
                             </Heading>
-                            <p className="mb-8 text-zinc-300 max-w-2xl text-lg">
+                            <p className="mb-8 max-w-2xl text-lg font-medium">
                                 Full-stack AI app starter kit with TypeScript,
                                 React Router, Better Auth, and Anthropic. Ship
                                 faster, not from scratch.
                             </p>
                             <Button
-                                className="self-start"
+                                className="self-start bg-black text-primary-400 border-black shadow-[4px_4px_0_0_var(--color-primary-900)] dark:border-black dark:shadow-[4px_4px_0_0_var(--color-primary-900)]"
                                 color="primary"
                                 size="lg"
                                 to="/work/iridium"
@@ -117,15 +131,13 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                     </Card>
                     {/* Secondary projects: 3-column */}
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                        <Card className="p-0 grid overflow-hidden border border-primary-900/40 bg-zinc-900">
-                            <div className="col-start-1 row-start-1 p-8 text-white flex flex-col">
-                                <span className="text-xs uppercase tracking-widest text-primary-500 mb-3">
-                                    Open Source
+                        <Card className="p-0 grid overflow-hidden">
+                            <div className="col-start-1 row-start-1 p-8 flex flex-col">
+                                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400 mb-3">
+                                    No. 002 — Open Source
                                 </span>
-                                <Heading className="text-white">
-                                    Lone Star UI
-                                </Heading>
-                                <p className="mb-8 text-zinc-300">
+                                <Heading>Lone Star UI</Heading>
+                                <p className="mb-8 text-zinc-700 dark:text-zinc-300">
                                     A React 19 component library built with
                                     TypeScript, Tailwind CSS 4, and CVA.
                                     Publishes ESM-only to npm with full type
@@ -142,15 +154,13 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                                 </Button>
                             </div>
                         </Card>
-                        <Card className="p-0 grid overflow-hidden border border-primary-900/40 bg-zinc-900">
-                            <div className="col-start-1 row-start-1 p-8 text-white flex flex-col">
-                                <span className="text-xs uppercase tracking-widest text-primary-500 mb-3">
-                                    Learning
+                        <Card className="p-0 grid overflow-hidden">
+                            <div className="col-start-1 row-start-1 p-8 flex flex-col">
+                                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400 mb-3">
+                                    No. 003 — Learning
                                 </span>
-                                <Heading className="text-white">
-                                    AI Maniacs
-                                </Heading>
-                                <p className="mb-8 text-zinc-300">
+                                <Heading>AI Maniacs</Heading>
+                                <p className="mb-8 text-zinc-700 dark:text-zinc-300">
                                     Free AI education platform. Fundamentals
                                     through agent workflows, built to keep up
                                     with how fast the field moves.
@@ -166,15 +176,13 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                                 </Button>
                             </div>
                         </Card>
-                        <Card className="p-0 grid overflow-hidden border border-primary-900/40 bg-zinc-900">
-                            <div className="col-start-1 row-start-1 p-8 text-white flex flex-col">
-                                <span className="text-xs uppercase tracking-widest text-primary-500 mb-3">
-                                    Product
+                        <Card className="p-0 grid overflow-hidden">
+                            <div className="col-start-1 row-start-1 p-8 flex flex-col">
+                                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400 mb-3">
+                                    No. 004 — Product
                                 </span>
-                                <Heading className="text-white">
-                                    Prompt Suite
-                                </Heading>
-                                <p className="mb-8 text-zinc-300">
+                                <Heading>Prompt Suite</Heading>
+                                <p className="mb-8 text-zinc-700 dark:text-zinc-300">
                                     Native desktop tray app for instant AI
                                     prompt access. Quick interactions without
                                     disrupting your workflow.
@@ -195,7 +203,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
             </HomeSection>
             {decks.length > 0 && (
                 <HomeSection>
-                    <div className="flex items-baseline justify-between mb-6">
+                    <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-8">
                         <Heading className="mb-0">Recent slides</Heading>
                         <Linky to="/slides" className="text-sm">
                             All slides →
@@ -203,21 +211,25 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                     </div>
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                         {decks.map((deck) => (
-                            <Linky key={deck.slug} to={`/slides/${deck.slug}`}>
-                                <Card className="h-full p-0 grid overflow-hidden border border-primary-900/40 bg-zinc-900 group hover:border-primary-700/60 transition-colors">
-                                    <div className="col-start-1 row-start-1 p-8 text-white flex flex-col">
-                                        <span className="text-xs uppercase tracking-widest text-primary-500 mb-3">
+                            <Linky
+                                key={deck.slug}
+                                to={`/slides/${deck.slug}`}
+                                className="block no-underline hover:bg-transparent hover:text-current dark:hover:text-current"
+                            >
+                                <Card className="h-full p-0 grid overflow-hidden group hover:bg-primary-400 dark:hover:bg-primary-400 hover:text-black dark:hover:text-black transition-colors duration-150">
+                                    <div className="col-start-1 row-start-1 p-8 flex flex-col">
+                                        <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400 group-hover:text-black mb-3">
                                             Deck
                                         </span>
-                                        <Heading className="text-white">
+                                        <Heading className="group-hover:text-black dark:group-hover:text-black">
                                             {deck.title}
                                         </Heading>
                                         {deck.description && (
-                                            <p className="mb-6 text-zinc-300">
+                                            <p className="mb-6 text-zinc-700 dark:text-zinc-300 group-hover:text-black">
                                                 {deck.description}
                                             </p>
                                         )}
-                                        <span className="mt-auto text-xs font-mono text-zinc-500">
+                                        <span className="mt-auto text-xs font-mono uppercase tracking-[0.15em] text-zinc-500 group-hover:text-black">
                                             {deck.slideCount} slide
                                             {deck.slideCount === 1 ? '' : 's'}
                                         </span>
@@ -229,7 +241,12 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                 </HomeSection>
             )}
             <HomeSection>
-                <Heading>Socials</Heading>
+                <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-8">
+                    <Heading className="mb-0">Socials</Heading>
+                    <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                        04
+                    </span>
+                </div>
                 <div className="flex gap-8">
                     <Linky
                         href="https://github.com/sethdavis512"

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -63,8 +63,8 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                     as="h1"
                     className="text-[clamp(3.5rem,10vw,8rem)] md:text-[clamp(3.5rem,10vw,8rem)] leading-[0.95] mb-8 tracking-tight"
                 >
-                    Seth
-                    <br />
+                    Seth{' '}
+                    <br className="md:hidden lg:inline" />
                     <span className="italic text-primary-600 dark:text-primary-400">
                         Davis
                     </span>
@@ -128,7 +128,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                         </div>
                     </Card>
                     {/* Secondary projects: 3-column */}
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                         <Card className="p-0 grid overflow-hidden">
                             <div className="col-start-1 row-start-1 p-8 flex flex-col">
                                 <span className="text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400 mb-3">
@@ -210,7 +210,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                             All slides →
                         </Linky>
                     </div>
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                         {decks.map((deck) => (
                             <Linky
                                 key={deck.slug}

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -9,6 +9,7 @@ import { XLogo } from '~/components/logos/XLogo';
 import { ContentStyles } from '~/constants';
 import { cx } from '~/cva.config';
 import { Card } from '~/components/Card';
+import { ServicesCallToAction } from '~/components/ServicesCallToAction';
 import { getAllDecks } from '~/content';
 import type { Route } from './+types/home';
 
@@ -197,6 +198,9 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                         </Card>
                     </div>
                 </div>
+            </HomeSection>
+            <HomeSection>
+                <ServicesCallToAction />
             </HomeSection>
             {decks.length > 0 && (
                 <HomeSection>

--- a/app/routes/resume.tsx
+++ b/app/routes/resume.tsx
@@ -42,11 +42,11 @@ export default function ResumeRoute({ loaderData }: Route.ComponentProps) {
 
     return (
         <>
-            <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-10">
+            <div className="flex items-baseline justify-between border-b border-zinc-200 dark:border-zinc-800 pb-3 mb-10">
                 <Heading as="h1" className="mb-0">
                     Resume
                 </Heading>
-                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                <span className="text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400">
                     The record
                 </span>
             </div>
@@ -62,7 +62,7 @@ export default function ResumeRoute({ loaderData }: Route.ComponentProps) {
             <div className="mb-8 flex flex-col sm:flex-row sm:items-center gap-x-4 gap-y-2 text-zinc-700 dark:text-zinc-300">
                 <a
                     href={`mailto:${CONTACT_EMAIL}`}
-                    className="inline-flex items-center gap-2 font-medium text-black dark:text-zinc-100 hover:bg-primary-400 hover:text-black dark:hover:text-black transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950"
+                    className="inline-flex items-center gap-2 font-medium text-black dark:text-zinc-100 hover:text-primary-700 dark:hover:text-primary-300 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950"
                 >
                     <MailIcon className="size-4" />
                     {CONTACT_EMAIL}

--- a/app/routes/resume.tsx
+++ b/app/routes/resume.tsx
@@ -42,9 +42,14 @@ export default function ResumeRoute({ loaderData }: Route.ComponentProps) {
 
     return (
         <>
-            <Heading as="h1" className="mb-8">
-                Resume
-            </Heading>
+            <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-10">
+                <Heading as="h1" className="mb-0">
+                    Resume
+                </Heading>
+                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                    The record
+                </span>
+            </div>
             <Banner className="mb-4">
                 <Flex>
                     <InfoIcon />
@@ -54,15 +59,15 @@ export default function ResumeRoute({ loaderData }: Route.ComponentProps) {
                     </Linky>
                 </Flex>
             </Banner>
-            <div className="mb-8 flex flex-col sm:flex-row sm:items-center gap-x-4 gap-y-2 text-zinc-300">
+            <div className="mb-8 flex flex-col sm:flex-row sm:items-center gap-x-4 gap-y-2 text-zinc-700 dark:text-zinc-300">
                 <a
                     href={`mailto:${CONTACT_EMAIL}`}
-                    className="inline-flex items-center gap-2 font-medium text-zinc-100 hover:text-primary-400 transition-colors duration-200 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+                    className="inline-flex items-center gap-2 font-medium text-black dark:text-zinc-100 hover:bg-primary-400 hover:text-black dark:hover:text-black transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950"
                 >
                     <MailIcon className="size-4" />
                     {CONTACT_EMAIL}
                 </a>
-                <span className="hidden sm:inline text-zinc-600">·</span>
+                <span className="hidden sm:inline text-zinc-400 dark:text-zinc-600">·</span>
                 <span>
                     Hiring or have a project?{' '}
                     <Linky to="/contact">Send me a message</Linky>

--- a/app/routes/service-detail.tsx
+++ b/app/routes/service-detail.tsx
@@ -1,9 +1,12 @@
-import { data } from 'react-router';
+import { data, redirect } from 'react-router';
 import type { Route } from './+types/service-detail';
 
 import { ServiceLanding } from '~/components/ServiceLanding';
 import { getPortfolioBase } from '~/airtable';
-import { getServiceOfferBySlug } from '~/content/data/service-offers';
+import {
+    getServiceOfferBySlug,
+    LEGACY_SERVICE_REDIRECTS
+} from '~/content/data/service-offers';
 import { getWorkBySlug } from '~/content';
 import { generateRouteMeta } from '~/utils/seo';
 import { validateContactForm } from '~/schemas/contact';
@@ -17,14 +20,35 @@ export function meta({ data: loaderData }: Route.MetaArgs) {
         });
     }
 
-    return generateRouteMeta({
-        pageTitle: loaderData.offer.shortTitle,
-        descriptionContent: loaderData.offer.seoDescription,
-        ogUrl: `https://sethdavis.tech/services/${loaderData.offer.slug}`
-    });
+    return [
+        ...generateRouteMeta({
+            pageTitle: loaderData.offer.shortTitle,
+            descriptionContent: loaderData.offer.seoDescription,
+            ogUrl: `https://sethdavis.tech/services/${loaderData.offer.slug}`
+        }),
+        {
+            'script:ld+json': {
+                '@context': 'https://schema.org',
+                '@type': 'FAQPage',
+                mainEntity: loaderData.offer.faq.map((item) => ({
+                    '@type': 'Question',
+                    name: item.question,
+                    acceptedAnswer: {
+                        '@type': 'Answer',
+                        text: item.answer
+                    }
+                }))
+            }
+        }
+    ];
 }
 
 export function loader({ params }: Route.LoaderArgs) {
+    const legacyTarget = LEGACY_SERVICE_REDIRECTS[params.slug!];
+    if (legacyTarget) {
+        throw redirect(legacyTarget, 301);
+    }
+
     const offer = getServiceOfferBySlug(params.slug!);
 
     if (!offer) {
@@ -55,13 +79,18 @@ export async function action({ request }: Route.ActionArgs) {
         return data({ fieldErrors: validation.fieldErrors }, { status: 400 });
     }
 
-    // The Airtable "Customers" table has no "Offer" field, so the requested
-    // offer is folded into Note instead of written as a separate column.
-    const message = validation.data.note?.trim();
-    const offer = validation.data.offer?.trim();
-    const note = [offer ? `[Service: ${offer}]` : '[Service inquiry]', message]
-        .filter(Boolean)
-        .join(' ');
+    // The Airtable "Customers" table only has First name/Last name/Email/Note,
+    // so the qualifying fields are folded into Note as labeled lines.
+    const { offer, company, budget, timeline, note: message } = validation.data;
+    const noteLines = [
+        offer && `Service: ${offer}`,
+        company && `Company: ${company}`,
+        budget && `Budget: ${budget}`,
+        timeline && `Timeline: ${timeline}`
+    ].filter(Boolean);
+    const note =
+        [noteLines.join('\n'), message?.trim()].filter(Boolean).join('\n\n') ||
+        '[Service inquiry]';
 
     try {
         const response = await getPortfolioBase()('Customers').create([

--- a/app/routes/services.tsx
+++ b/app/routes/services.tsx
@@ -1,6 +1,7 @@
-import { ArrowRight, Tag } from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
 import { Link } from 'react-router';
 
+import { Button } from '~/components/Button';
 import { Heading } from '~/components/Heading';
 import { Linky } from '~/components/Linky';
 import { generateRouteMeta } from '~/utils/seo';
@@ -10,7 +11,7 @@ export function meta() {
     return generateRouteMeta({
         pageTitle: 'Services',
         descriptionContent:
-            'Productized services from Seth Davis: custom CLI tools and Contentful-powered websites on React Router 7. Fixed scope, fixed price.',
+            'Design engineering services from Seth Davis: marketing sites, design systems, AI prototypes, and fractional design technologist retainers. Book a free scope call.',
         ogUrl: 'https://sethdavis.tech/services'
     });
 }
@@ -18,40 +19,48 @@ export function meta() {
 export default function ServicesRoute() {
     return (
         <>
-            <div className="border-b border-zinc-200 dark:border-zinc-800 pb-3 mb-8 text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400">
-                Services — Fixed scope, fixed price
-            </div>
+            <p className="text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400 mb-4">
+                Services
+            </p>
             <Heading as="h1" className="text-5xl md:text-7xl mb-6">
-                Two things I build,{' '}
+                Design engineering for teams{' '}
                 <span className="italic text-primary-600 dark:text-primary-400">
-                    on a fixed price.
+                    shipping with AI.
                 </span>
             </Heading>
             <p className="text-xl md:text-2xl text-zinc-700 dark:text-zinc-300 max-w-3xl mb-4">
-                Developer CLI tools and Contentful-powered websites. Each one
-                is a productized engagement with a written scope and a fixed
-                cost, so you know what you're getting before you sign.
+                Sites, design systems, and working AI prototypes, built by one
+                senior design technologist who moves at agent speed and reviews
+                like a human. Every engagement starts with a free scope call.
             </p>
-            <p className="text-zinc-600 dark:text-zinc-400 max-w-3xl mb-12">
-                Need something else?{' '}
+            <p className="text-zinc-600 dark:text-zinc-400 max-w-3xl mb-8">
+                Not sure which shape fits?{' '}
                 <Linky href="https://tidycal.com/sethdavis512/meet-and-greet">
-                    Book a scope call
+                    Book the call
                 </Linky>{' '}
-                and we can figure out whether it's a fit.
+                and we'll figure it out together in 30 minutes.
             </p>
+            <div className="mb-12 flex">
+                <Button
+                    href="https://tidycal.com/sethdavis512/meet-and-greet"
+                    size="lg"
+                    iconAfter={<ArrowRight className="size-4" />}
+                >
+                    Book a scope call
+                </Button>
+            </div>
             <div className="grid gap-6 md:grid-cols-2">
                 {serviceOffers.map((offer) => (
                     <Link
                         key={offer.slug}
                         to={`/services/${offer.slug}`}
-                        className="group border border-zinc-200 dark:border-zinc-800 transition-shadow duration-150 hover:border-primary-500/60 p-6 flex flex-col"
+                        className="group rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 transition-colors duration-200 hover:border-primary-500/60 p-6 flex flex-col"
                     >
-                        <div className="flex flex-wrap items-center gap-2 mb-4">
-                            <span className="inline-flex items-center gap-1.5 rounded-full bg-primary-500/15 text-primary-800 dark:text-primary-300 px-2.5 py-1 text-xs font-medium">
-                                <Tag className="size-3" />
-                                From {offer.startingPrice}
-                            </span>
-                        </div>
+                        <p className="text-xs font-medium tracking-wide text-primary-700 dark:text-primary-300 mb-4">
+                            {offer.kind === 'retainer'
+                                ? 'Ongoing retainer'
+                                : 'Project engagement'}
+                        </p>
                         <Heading as="h2" size="3" className="mb-3">
                             {offer.shortTitle}
                         </Heading>
@@ -62,7 +71,7 @@ export default function ServicesRoute() {
                             {offer.proofLine}
                         </p>
                         <span className="inline-flex items-center gap-1.5 text-sm font-medium text-primary-700 dark:text-primary-300">
-                            See offer details
+                            See details
                             <ArrowRight className="size-4 transition-transform duration-200 group-hover:translate-x-0.5" />
                         </span>
                     </Link>

--- a/app/routes/services.tsx
+++ b/app/routes/services.tsx
@@ -18,15 +18,21 @@ export function meta() {
 export default function ServicesRoute() {
     return (
         <>
-            <Heading as="h1" className="text-4xl md:text-6xl font-black mb-6">
-                Two things I build, on a fixed price.
+            <div className="border-b-2 border-black dark:border-zinc-200 pb-3 mb-8 font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                Services — Fixed scope, fixed price
+            </div>
+            <Heading as="h1" className="text-5xl md:text-7xl mb-6">
+                Two things I build,{' '}
+                <span className="italic text-primary-600 dark:text-primary-400">
+                    on a fixed price.
+                </span>
             </Heading>
-            <p className="text-xl md:text-2xl text-zinc-300 max-w-3xl mb-4">
+            <p className="text-xl md:text-2xl text-zinc-700 dark:text-zinc-300 max-w-3xl mb-4">
                 Developer CLI tools and Contentful-powered websites. Each one
                 is a productized engagement with a written scope and a fixed
                 cost, so you know what you're getting before you sign.
             </p>
-            <p className="text-zinc-400 max-w-3xl mb-12">
+            <p className="text-zinc-600 dark:text-zinc-400 max-w-3xl mb-12">
                 Need something else?{' '}
                 <Linky href="https://tidycal.com/sethdavis512/meet-and-greet">
                     Book a scope call
@@ -38,10 +44,10 @@ export default function ServicesRoute() {
                     <Link
                         key={offer.slug}
                         to={`/services/${offer.slug}`}
-                        className="group rounded-xl bg-zinc-900 border border-zinc-800 hover:border-primary-500/50 transition-colors duration-200 p-6 flex flex-col"
+                        className="group border-2 border-black dark:border-zinc-200 transition-shadow duration-150 hover:shadow-[8px_8px_0_0_var(--color-black)] dark:hover:shadow-[8px_8px_0_0_var(--color-zinc-200)] p-6 flex flex-col"
                     >
                         <div className="flex flex-wrap items-center gap-2 mb-4">
-                            <span className="inline-flex items-center gap-1.5 rounded-full bg-primary-500/15 text-primary-300 px-2.5 py-0.5 text-xs font-medium">
+                            <span className="inline-flex items-center gap-1.5 bg-primary-400 text-black px-2.5 py-1 font-mono text-xs uppercase tracking-[0.12em]">
                                 <Tag className="size-3" />
                                 From {offer.startingPrice}
                             </span>
@@ -49,13 +55,13 @@ export default function ServicesRoute() {
                         <Heading as="h2" size="3" className="mb-3">
                             {offer.shortTitle}
                         </Heading>
-                        <p className="text-zinc-300 mb-4 flex-1">
+                        <p className="text-zinc-700 dark:text-zinc-300 mb-4 flex-1">
                             {offer.tagline}
                         </p>
                         <p className="text-sm text-zinc-500 mb-5">
                             {offer.proofLine}
                         </p>
-                        <span className="inline-flex items-center gap-1.5 text-primary-400 group-hover:text-primary-300 font-medium">
+                        <span className="inline-flex items-center gap-1.5 font-mono text-xs uppercase tracking-[0.15em] text-black dark:text-white font-semibold">
                             See offer details
                             <ArrowRight className="size-4 transition-transform duration-200 group-hover:translate-x-0.5" />
                         </span>

--- a/app/routes/services.tsx
+++ b/app/routes/services.tsx
@@ -18,7 +18,7 @@ export function meta() {
 export default function ServicesRoute() {
     return (
         <>
-            <div className="border-b-2 border-black dark:border-zinc-200 pb-3 mb-8 font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+            <div className="border-b border-zinc-200 dark:border-zinc-800 pb-3 mb-8 text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400">
                 Services — Fixed scope, fixed price
             </div>
             <Heading as="h1" className="text-5xl md:text-7xl mb-6">
@@ -44,10 +44,10 @@ export default function ServicesRoute() {
                     <Link
                         key={offer.slug}
                         to={`/services/${offer.slug}`}
-                        className="group border-2 border-black dark:border-zinc-200 transition-shadow duration-150 hover:shadow-[8px_8px_0_0_var(--color-black)] dark:hover:shadow-[8px_8px_0_0_var(--color-zinc-200)] p-6 flex flex-col"
+                        className="group border border-zinc-200 dark:border-zinc-800 transition-shadow duration-150 hover:border-primary-500/60 p-6 flex flex-col"
                     >
                         <div className="flex flex-wrap items-center gap-2 mb-4">
-                            <span className="inline-flex items-center gap-1.5 bg-primary-400 text-black px-2.5 py-1 font-mono text-xs uppercase tracking-[0.12em]">
+                            <span className="inline-flex items-center gap-1.5 rounded-full bg-primary-500/15 text-primary-800 dark:text-primary-300 px-2.5 py-1 text-xs font-medium">
                                 <Tag className="size-3" />
                                 From {offer.startingPrice}
                             </span>
@@ -61,7 +61,7 @@ export default function ServicesRoute() {
                         <p className="text-sm text-zinc-500 mb-5">
                             {offer.proofLine}
                         </p>
-                        <span className="inline-flex items-center gap-1.5 font-mono text-xs uppercase tracking-[0.15em] text-black dark:text-white font-semibold">
+                        <span className="inline-flex items-center gap-1.5 text-sm font-medium text-primary-700 dark:text-primary-300">
                             See offer details
                             <ArrowRight className="size-4 transition-transform duration-200 group-hover:translate-x-0.5" />
                         </span>

--- a/app/routes/slides-index.tsx
+++ b/app/routes/slides-index.tsx
@@ -30,11 +30,11 @@ export default function SlidesIndexRoute({
 }: Route.ComponentProps) {
     return (
         <>
-            <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-4">
+            <div className="flex items-baseline justify-between border-b border-zinc-200 dark:border-zinc-800 pb-3 mb-4">
                 <Heading as="h1" className="mb-0">
                     Slides
                 </Heading>
-                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                <span className="text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400">
                     Talks & decks
                 </span>
             </div>
@@ -50,7 +50,7 @@ export default function SlidesIndexRoute({
                             to={`/slides/${deck.slug}`}
                             className="block no-underline hover:bg-transparent hover:text-current dark:hover:text-current"
                         >
-                            <Card className="w-full group transition-shadow duration-150 hover:shadow-[6px_6px_0_0_var(--color-black)] dark:hover:shadow-[6px_6px_0_0_var(--color-zinc-200)]">
+                            <Card className="w-full group transition-shadow duration-150 hover:border-primary-500/60">
                                 <div className="flex items-start justify-between gap-4">
                                     <div className="flex-1 min-w-0">
                                         <Heading as="h3" size="4">
@@ -61,7 +61,7 @@ export default function SlidesIndexRoute({
                                                 {deck.description}
                                             </p>
                                         )}
-                                        <p className="text-zinc-500 text-xs mt-3 font-mono uppercase tracking-[0.15em]">
+                                        <p className="text-zinc-500 text-xs mt-3 font-medium tracking-wide">
                                             {deck.slideCount} slide
                                             {deck.slideCount === 1 ? '' : 's'}
                                         </p>

--- a/app/routes/slides-index.tsx
+++ b/app/routes/slides-index.tsx
@@ -30,29 +30,38 @@ export default function SlidesIndexRoute({
 }: Route.ComponentProps) {
     return (
         <>
-            <Heading as="h1" className="mb-2">
-                Slides
-            </Heading>
-            <p className="text-zinc-400 mb-8">
+            <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-4">
+                <Heading as="h1" className="mb-0">
+                    Slides
+                </Heading>
+                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                    Talks & decks
+                </span>
+            </div>
+            <p className="text-zinc-600 dark:text-zinc-400 mb-8">
                 Decks and talk walkthroughs. Use ← and → to navigate once you're
                 inside a deck.
             </p>
             <div className="flex flex-col gap-3">
                 {loaderData.decks.length > 0 ? (
                     loaderData.decks.map((deck) => (
-                        <Linky key={deck.slug} to={`/slides/${deck.slug}`}>
-                            <Card className="w-full group border border-zinc-800 hover:border-zinc-600 dark:hover:border-zinc-500 transition-colors duration-200 hover:bg-zinc-800/60 dark:hover:bg-zinc-800/60">
+                        <Linky
+                            key={deck.slug}
+                            to={`/slides/${deck.slug}`}
+                            className="block no-underline hover:bg-transparent hover:text-current dark:hover:text-current"
+                        >
+                            <Card className="w-full group transition-shadow duration-150 hover:shadow-[6px_6px_0_0_var(--color-black)] dark:hover:shadow-[6px_6px_0_0_var(--color-zinc-200)]">
                                 <div className="flex items-start justify-between gap-4">
                                     <div className="flex-1 min-w-0">
                                         <Heading as="h3" size="4">
                                             {deck.title}
                                         </Heading>
                                         {deck.description && (
-                                            <p className="text-zinc-400 text-sm mt-1 line-clamp-2">
+                                            <p className="text-zinc-600 dark:text-zinc-400 text-sm mt-1 line-clamp-2">
                                                 {deck.description}
                                             </p>
                                         )}
-                                        <p className="text-zinc-500 text-xs mt-3 font-mono">
+                                        <p className="text-zinc-500 text-xs mt-3 font-mono uppercase tracking-[0.15em]">
                                             {deck.slideCount} slide
                                             {deck.slideCount === 1 ? '' : 's'}
                                         </p>
@@ -76,7 +85,7 @@ export default function SlidesIndexRoute({
                         </Linky>
                     ))
                 ) : (
-                    <p className="text-zinc-400">No decks yet.</p>
+                    <p className="text-zinc-600 dark:text-zinc-400">No decks yet.</p>
                 )}
             </div>
         </>

--- a/app/routes/thank-you.tsx
+++ b/app/routes/thank-you.tsx
@@ -18,8 +18,8 @@ export default function ThankYouRoute() {
     return (
         <div className="max-w-3xl mx-auto">
             <div className="text-center mb-8">
-                <div className="inline-flex items-center justify-center w-20 h-20 border-2 border-black dark:border-zinc-200 bg-primary-400 mb-6">
-                    <CheckCircle2 className="w-10 h-10 text-black" />
+                <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-primary-500/15 mb-6">
+                    <CheckCircle2 className="w-10 h-10 text-primary-700 dark:text-primary-300" />
                 </div>
                 <Heading as="h1" className="mb-4">
                     Thank You for Your Purchase!
@@ -75,12 +75,12 @@ export default function ThankYouRoute() {
                     </div>
                 </Card>
 
-                <Card className="bg-black text-white dark:bg-zinc-900">
+                <Card className="bg-zinc-50 dark:bg-zinc-900">
                     <div className="space-y-3">
-                        <Heading as="h2" size="4" className="text-white">
+                        <Heading as="h2" size="4">
                             What's Next?
                         </Heading>
-                        <p className="text-zinc-300">
+                        <p className="text-zinc-600 dark:text-zinc-300">
                             Explore more of my work, check out other projects,
                             or get in touch if you'd like to collaborate on
                             something new.

--- a/app/routes/thank-you.tsx
+++ b/app/routes/thank-you.tsx
@@ -18,8 +18,8 @@ export default function ThankYouRoute() {
     return (
         <div className="max-w-3xl mx-auto">
             <div className="text-center mb-8">
-                <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-emerald-500/10 mb-6">
-                    <CheckCircle2 className="w-10 h-10 text-emerald-500" />
+                <div className="inline-flex items-center justify-center w-20 h-20 border-2 border-black dark:border-zinc-200 bg-primary-400 mb-6">
+                    <CheckCircle2 className="w-10 h-10 text-black" />
                 </div>
                 <Heading as="h1" className="mb-4">
                     Thank You for Your Purchase!
@@ -75,9 +75,9 @@ export default function ThankYouRoute() {
                     </div>
                 </Card>
 
-                <Card className="bg-zinc-800 border border-zinc-700">
+                <Card className="bg-black text-white dark:bg-zinc-900">
                     <div className="space-y-3">
-                        <Heading as="h2" size="4">
+                        <Heading as="h2" size="4" className="text-white">
                             What's Next?
                         </Heading>
                         <p className="text-zinc-300">

--- a/app/routes/til-detail.tsx
+++ b/app/routes/til-detail.tsx
@@ -38,8 +38,8 @@ export default function TILDetailRoute({ loaderData }: Route.ComponentProps) {
 
     return (
         <>
-            <div className="mb-8 border-b-2 border-black dark:border-zinc-200 pb-6">
-                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400 block mb-3">
+            <div className="mb-8 border-b border-zinc-200 dark:border-zinc-800 pb-6">
+                <span className="text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400 block mb-3">
                     TIL — Field note
                 </span>
                 <Heading as="h1" size="1" className="mb-2">

--- a/app/routes/til-detail.tsx
+++ b/app/routes/til-detail.tsx
@@ -38,10 +38,15 @@ export default function TILDetailRoute({ loaderData }: Route.ComponentProps) {
 
     return (
         <>
-            <div className="mb-8">
-                <Heading className="mb-2">{loaderData.post.title}</Heading>
+            <div className="mb-8 border-b-2 border-black dark:border-zinc-200 pb-6">
+                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400 block mb-3">
+                    TIL — Field note
+                </span>
+                <Heading as="h1" size="1" className="mb-2">
+                    {loaderData.post.title}
+                </Heading>
                 {loaderData.post.tags.length > 0 && (
-                    <ul className="flex gap-2 mt-3">
+                    <ul className="flex gap-2 mt-4">
                         {loaderData.post.tags.map((tag) => (
                             <li key={tag}>
                                 <Tag>{tag}</Tag>

--- a/app/routes/til.tsx
+++ b/app/routes/til.tsx
@@ -65,10 +65,15 @@ export default function TILRoute({ loaderData }: Route.ComponentProps) {
 
     return (
         <>
-            <Heading as="h1" className="mb-2">
-                TIL
-            </Heading>
-            <p className="text-zinc-400 mb-8">
+            <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-4">
+                <Heading as="h1" className="mb-0">
+                    TIL
+                </Heading>
+                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                    Field notes
+                </span>
+            </div>
+            <p className="text-zinc-600 dark:text-zinc-400 mb-8">
                 Short things I have learned — snippets, discoveries, and quick
                 explanations.
             </p>
@@ -127,15 +132,19 @@ export default function TILRoute({ loaderData }: Route.ComponentProps) {
             <div className="flex flex-col gap-3">
                 {pagedPosts.length > 0 ? (
                     pagedPosts.map((post) => (
-                        <Linky key={post.id} to={`/til/${post.slug}`}>
-                            <Card className="w-full group border border-zinc-800 hover:border-zinc-600 dark:hover:border-zinc-500 transition-colors duration-200 hover:bg-zinc-800/60 dark:hover:bg-zinc-800/60">
+                        <Linky
+                            key={post.id}
+                            to={`/til/${post.slug}`}
+                            className="block no-underline hover:bg-transparent hover:text-current dark:hover:text-current"
+                        >
+                            <Card className="w-full group transition-shadow duration-150 hover:shadow-[6px_6px_0_0_var(--color-black)] dark:hover:shadow-[6px_6px_0_0_var(--color-zinc-200)]">
                                 <div className="flex items-start justify-between gap-4">
                                     <div className="flex-1 min-w-0">
                                         <Heading as="h3" size="4">
                                             {post.title}
                                         </Heading>
                                         {post.excerpt && (
-                                            <p className="text-zinc-400 text-sm mt-1 line-clamp-2">
+                                            <p className="text-zinc-600 dark:text-zinc-400 text-sm mt-1 line-clamp-2">
                                                 {post.excerpt}
                                             </p>
                                         )}
@@ -164,11 +173,11 @@ export default function TILRoute({ loaderData }: Route.ComponentProps) {
                         </Linky>
                     ))
                 ) : activeTopic ? (
-                    <p className="text-zinc-400">
+                    <p className="text-zinc-600 dark:text-zinc-400">
                         No TILs tagged <code>{activeTopic}</code> yet.
                     </p>
                 ) : (
-                    <p className="text-zinc-400">
+                    <p className="text-zinc-600 dark:text-zinc-400">
                         Nothing here yet — check back soon.
                     </p>
                 )}
@@ -181,20 +190,20 @@ export default function TILRoute({ loaderData }: Route.ComponentProps) {
                     {currentPage > 1 ? (
                         <Link
                             to={pageHref(currentPage - 1)}
-                            className="text-sm text-zinc-300 hover:text-white"
+                            className="font-mono text-xs uppercase tracking-[0.15em] text-zinc-700 dark:text-zinc-300 hover:bg-primary-400 hover:text-black px-2 py-1"
                         >
                             ← Newer
                         </Link>
                     ) : (
                         <span />
                     )}
-                    <span className="text-sm text-zinc-500">
+                    <span className="font-mono text-xs uppercase tracking-[0.15em] text-zinc-500">
                         Page {currentPage} of {totalPages}
                     </span>
                     {currentPage < totalPages ? (
                         <Link
                             to={pageHref(currentPage + 1)}
-                            className="text-sm text-zinc-300 hover:text-white"
+                            className="font-mono text-xs uppercase tracking-[0.15em] text-zinc-700 dark:text-zinc-300 hover:bg-primary-400 hover:text-black px-2 py-1"
                         >
                             Older →
                         </Link>

--- a/app/routes/til.tsx
+++ b/app/routes/til.tsx
@@ -65,11 +65,11 @@ export default function TILRoute({ loaderData }: Route.ComponentProps) {
 
     return (
         <>
-            <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-4">
+            <div className="flex items-baseline justify-between border-b border-zinc-200 dark:border-zinc-800 pb-3 mb-4">
                 <Heading as="h1" className="mb-0">
                     TIL
                 </Heading>
-                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                <span className="text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400">
                     Field notes
                 </span>
             </div>
@@ -137,7 +137,7 @@ export default function TILRoute({ loaderData }: Route.ComponentProps) {
                             to={`/til/${post.slug}`}
                             className="block no-underline hover:bg-transparent hover:text-current dark:hover:text-current"
                         >
-                            <Card className="w-full group transition-shadow duration-150 hover:shadow-[6px_6px_0_0_var(--color-black)] dark:hover:shadow-[6px_6px_0_0_var(--color-zinc-200)]">
+                            <Card className="w-full group transition-shadow duration-150 hover:border-primary-500/60">
                                 <div className="flex items-start justify-between gap-4">
                                     <div className="flex-1 min-w-0">
                                         <Heading as="h3" size="4">
@@ -190,20 +190,20 @@ export default function TILRoute({ loaderData }: Route.ComponentProps) {
                     {currentPage > 1 ? (
                         <Link
                             to={pageHref(currentPage - 1)}
-                            className="font-mono text-xs uppercase tracking-[0.15em] text-zinc-700 dark:text-zinc-300 hover:bg-primary-400 hover:text-black px-2 py-1"
+                            className="text-xs font-medium tracking-wide text-zinc-700 dark:text-zinc-300 hover:text-primary-700 dark:hover:text-primary-300 px-2 py-1"
                         >
                             ← Newer
                         </Link>
                     ) : (
                         <span />
                     )}
-                    <span className="font-mono text-xs uppercase tracking-[0.15em] text-zinc-500">
+                    <span className="text-xs font-medium tracking-wide text-zinc-500">
                         Page {currentPage} of {totalPages}
                     </span>
                     {currentPage < totalPages ? (
                         <Link
                             to={pageHref(currentPage + 1)}
-                            className="font-mono text-xs uppercase tracking-[0.15em] text-zinc-700 dark:text-zinc-300 hover:bg-primary-400 hover:text-black px-2 py-1"
+                            className="text-xs font-medium tracking-wide text-zinc-700 dark:text-zinc-300 hover:text-primary-700 dark:hover:text-primary-300 px-2 py-1"
                         >
                             Older →
                         </Link>

--- a/app/routes/truck.tsx
+++ b/app/routes/truck.tsx
@@ -72,7 +72,7 @@ export default function TruckRoute({ loaderData }: Route.ComponentProps) {
             <ResponsiveImage
                 src="https://res.cloudinary.com/setholito/image/upload/c_scale,f_auto,q_90,w_1920/v1/portfolio/truck-1.jpg"
                 alt="Black 2023 Ford F-150"
-                className="border-2 border-black dark:border-zinc-200"
+                className="border border-zinc-200 dark:border-zinc-800"
             />
             <Divider className="my-8" />
             <div className="grid grid-cols-1 gap-4 md:grid-cols-12">
@@ -82,7 +82,7 @@ export default function TruckRoute({ loaderData }: Route.ComponentProps) {
                 {loaderData.upgrades.map((upgrade) => (
                     <div key={upgrade.id} className="col-span-1 md:col-span-4">
                         <a href={upgrade.url} target="_blank" rel="noreferrer">
-                            <Card className="flex flex-col overflow-hidden transition-shadow duration-150 hover:shadow-[6px_6px_0_0_var(--color-black)] dark:hover:shadow-[6px_6px_0_0_var(--color-zinc-200)]">
+                            <Card className="flex flex-col overflow-hidden transition-shadow duration-150 hover:border-primary-500/60">
                                 <div className="-mx-4 -mt-4 mb-4">
                                     <ResponsiveImage
                                         src={upgrade.img}
@@ -125,7 +125,7 @@ export default function TruckRoute({ loaderData }: Route.ComponentProps) {
                             target="_blank"
                             rel="noreferrer"
                         >
-                            <Card className="flex flex-col overflow-hidden transition-shadow duration-150 hover:shadow-[6px_6px_0_0_var(--color-black)] dark:hover:shadow-[6px_6px_0_0_var(--color-zinc-200)]">
+                            <Card className="flex flex-col overflow-hidden transition-shadow duration-150 hover:border-primary-500/60">
                                 <div className="-mx-4 -mt-4 mb-4">
                                     <ResponsiveImage
                                         src={accessory.img}

--- a/app/routes/truck.tsx
+++ b/app/routes/truck.tsx
@@ -72,7 +72,7 @@ export default function TruckRoute({ loaderData }: Route.ComponentProps) {
             <ResponsiveImage
                 src="https://res.cloudinary.com/setholito/image/upload/c_scale,f_auto,q_90,w_1920/v1/portfolio/truck-1.jpg"
                 alt="Black 2023 Ford F-150"
-                className="rounded-lg border border-zinc-300 dark:border-zinc-700"
+                className="border-2 border-black dark:border-zinc-200"
             />
             <Divider className="my-8" />
             <div className="grid grid-cols-1 gap-4 md:grid-cols-12">
@@ -82,7 +82,7 @@ export default function TruckRoute({ loaderData }: Route.ComponentProps) {
                 {loaderData.upgrades.map((upgrade) => (
                     <div key={upgrade.id} className="col-span-1 md:col-span-4">
                         <a href={upgrade.url} target="_blank" rel="noreferrer">
-                            <Card className="flex flex-col border border-transparent hover:border hover:border-green-500 overflow-hidden">
+                            <Card className="flex flex-col overflow-hidden transition-shadow duration-150 hover:shadow-[6px_6px_0_0_var(--color-black)] dark:hover:shadow-[6px_6px_0_0_var(--color-zinc-200)]">
                                 <div className="-mx-4 -mt-4 mb-4">
                                     <ResponsiveImage
                                         src={upgrade.img}
@@ -125,7 +125,7 @@ export default function TruckRoute({ loaderData }: Route.ComponentProps) {
                             target="_blank"
                             rel="noreferrer"
                         >
-                            <Card className="flex flex-col border border-transparent hover:border hover:border-green-500 overflow-hidden">
+                            <Card className="flex flex-col overflow-hidden transition-shadow duration-150 hover:shadow-[6px_6px_0_0_var(--color-black)] dark:hover:shadow-[6px_6px_0_0_var(--color-zinc-200)]">
                                 <div className="-mx-4 -mt-4 mb-4">
                                     <ResponsiveImage
                                         src={accessory.img}

--- a/app/routes/work.tsx
+++ b/app/routes/work.tsx
@@ -48,21 +48,29 @@ function FeaturedWorkDisplay({
     reverse
 }: WorkDisplayProps) {
     return (
-        <Link to={url}>
-            <div className="hover:scale-[101%] transition-all duration-200 hover:bg-zinc-100 hover:dark:bg-zinc-900 rounded-lg h-full">
+        <Link to={url} className="group block h-full">
+            <div className="border-2 border-black dark:border-zinc-200 h-full transition-shadow duration-150 group-hover:shadow-[8px_8px_0_0_var(--color-black)] dark:group-hover:shadow-[8px_8px_0_0_var(--color-zinc-200)]">
                 <div
                     className={cx(
                         `flex flex-col lg:flex-row items-center gap-8 p-6`,
                         reverse && 'lg:flex-row-reverse'
                     )}
                 >
-                    <img className="w-125" src={imageSrc} alt={imageAlt} />
+                    <img
+                        className="w-125 border-2 border-black dark:border-zinc-200"
+                        src={imageSrc}
+                        alt={imageAlt}
+                    />
                     <div className={cx(`text-center lg:text-left flex-1`)}>
-                        <Heading as="h2" className="text-3xl font-bold">
+                        <Heading as="h2" className="text-3xl md:text-4xl">
                             {title}
                         </Heading>
-                        <p className="mb-8">{description}</p>
-                        <span className={buttonVariants()}>{cta}</span>
+                        <p className="mb-8 text-zinc-700 dark:text-zinc-300">
+                            {description}
+                        </p>
+                        <span className={buttonVariants({ variant: 'outline' })}>
+                            {cta}
+                        </span>
                     </div>
                 </div>
             </div>
@@ -79,11 +87,11 @@ function CompactWorkCard({
 }: Omit<WorkDisplayProps, 'cta' | 'reverse'>) {
     return (
         <Link to={url} className="group">
-            <div className="rounded-lg overflow-hidden bg-zinc-900 border border-zinc-800 hover:border-zinc-700 transition-colors duration-200 h-full flex flex-col">
+            <div className="overflow-hidden border-2 border-black dark:border-zinc-200 transition-shadow duration-150 group-hover:shadow-[6px_6px_0_0_var(--color-black)] dark:group-hover:shadow-[6px_6px_0_0_var(--color-zinc-200)] h-full flex flex-col">
                 {imageSrc && (
-                    <div className="aspect-video overflow-hidden">
+                    <div className="aspect-video overflow-hidden border-b-2 border-black dark:border-zinc-200">
                         <img
-                            className="w-full h-full object-cover group-hover:scale-[103%] transition-transform duration-300"
+                            className="w-full h-full object-cover"
                             src={imageSrc}
                             alt={imageAlt}
                         />
@@ -93,7 +101,7 @@ function CompactWorkCard({
                     <Heading as="h3" size="4" className="mb-2">
                         {title}
                     </Heading>
-                    <p className="text-sm text-zinc-400 line-clamp-2">
+                    <p className="text-sm text-zinc-600 dark:text-zinc-400 line-clamp-2">
                         {description}
                     </p>
                 </div>
@@ -110,7 +118,14 @@ export default function WorkRoute({ loaderData }: Route.ComponentProps) {
 
     return (
         <>
-            <Heading as="h1">Work</Heading>
+            <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-10">
+                <Heading as="h1" className="mb-0">
+                    Work
+                </Heading>
+                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                    Selected projects
+                </span>
+            </div>
             <div className="grid grid-cols-1 gap-8 items-stretch mb-12">
                 {featured.map(function (item, index) {
                     return (
@@ -130,9 +145,11 @@ export default function WorkRoute({ loaderData }: Route.ComponentProps) {
             </div>
             {rest.length > 0 && (
                 <>
-                    <Heading as="h2" size="3" className="mb-6">
-                        More projects
-                    </Heading>
+                    <div className="border-b-2 border-black dark:border-zinc-200 pb-3 mb-8">
+                        <Heading as="h2" size="3" className="mb-0">
+                            More projects
+                        </Heading>
+                    </div>
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
                         {rest.map(function (item) {
                             return (

--- a/app/routes/work.tsx
+++ b/app/routes/work.tsx
@@ -49,7 +49,7 @@ function FeaturedWorkDisplay({
 }: WorkDisplayProps) {
     return (
         <Link to={url} className="group block h-full">
-            <div className="border-2 border-black dark:border-zinc-200 h-full transition-shadow duration-150 group-hover:shadow-[8px_8px_0_0_var(--color-black)] dark:group-hover:shadow-[8px_8px_0_0_var(--color-zinc-200)]">
+            <div className="border border-zinc-200 dark:border-zinc-800 h-full transition-shadow duration-150 group-hover:border-primary-500/60">
                 <div
                     className={cx(
                         `flex flex-col lg:flex-row items-center gap-8 p-6`,
@@ -57,7 +57,7 @@ function FeaturedWorkDisplay({
                     )}
                 >
                     <img
-                        className="w-125 border-2 border-black dark:border-zinc-200"
+                        className="w-125 border border-zinc-200 dark:border-zinc-800"
                         src={imageSrc}
                         alt={imageAlt}
                     />
@@ -87,9 +87,9 @@ function CompactWorkCard({
 }: Omit<WorkDisplayProps, 'cta' | 'reverse'>) {
     return (
         <Link to={url} className="group">
-            <div className="overflow-hidden border-2 border-black dark:border-zinc-200 transition-shadow duration-150 group-hover:shadow-[6px_6px_0_0_var(--color-black)] dark:group-hover:shadow-[6px_6px_0_0_var(--color-zinc-200)] h-full flex flex-col">
+            <div className="overflow-hidden border border-zinc-200 dark:border-zinc-800 transition-shadow duration-150 group-hover:border-primary-500/60 h-full flex flex-col">
                 {imageSrc && (
-                    <div className="aspect-video overflow-hidden border-b-2 border-black dark:border-zinc-200">
+                    <div className="aspect-video overflow-hidden border-b border-zinc-200 dark:border-zinc-800">
                         <img
                             className="w-full h-full object-cover"
                             src={imageSrc}
@@ -118,11 +118,11 @@ export default function WorkRoute({ loaderData }: Route.ComponentProps) {
 
     return (
         <>
-            <div className="flex items-baseline justify-between border-b-2 border-black dark:border-zinc-200 pb-3 mb-10">
+            <div className="flex items-baseline justify-between border-b border-zinc-200 dark:border-zinc-800 pb-3 mb-10">
                 <Heading as="h1" className="mb-0">
                     Work
                 </Heading>
-                <span className="font-mono text-xs uppercase tracking-[0.25em] text-zinc-600 dark:text-zinc-400">
+                <span className="text-xs font-medium tracking-wide text-zinc-600 dark:text-zinc-400">
                     Selected projects
                 </span>
             </div>
@@ -145,7 +145,7 @@ export default function WorkRoute({ loaderData }: Route.ComponentProps) {
             </div>
             {rest.length > 0 && (
                 <>
-                    <div className="border-b-2 border-black dark:border-zinc-200 pb-3 mb-8">
+                    <div className="border-b border-zinc-200 dark:border-zinc-800 pb-3 mb-8">
                         <Heading as="h2" size="3" className="mb-0">
                             More projects
                         </Heading>

--- a/app/routes/wrapper.tsx
+++ b/app/routes/wrapper.tsx
@@ -6,9 +6,8 @@ import { Button } from '~/components/Button';
 import { Flex } from '~/components/Flex';
 import { KeyboardShortcut } from '~/components/KeyboardShortcut';
 import { Logo } from '~/components/logos/SethDavisLogo';
-import { BorderStyles } from '~/constants';
 
-const sharedLinkClasses = `text-4xl md:text-lg`;
+const sharedLinkClasses = `text-3xl md:text-sm font-mono uppercase tracking-[0.15em]`;
 
 interface NavItem {
     type: 'internal' | 'external';
@@ -82,12 +81,11 @@ function AppNavLink({ to, children, ariaLabel, onClick }: AppNavLinkProps) {
             className={({ isActive }) =>
                 cx(
                     sharedLinkClasses,
-                    `transition-colors duration-200 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-900 py-3 px-4`,
-                    `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950`,
-                    isActive &&
-                        `text-zinc-900 dark:text-white font-bold bg-zinc-100 dark:bg-zinc-900`,
+                    `transition-colors duration-150 py-2 px-3`,
+                    `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950`,
+                    isActive && `bg-primary-400 text-black font-semibold`,
                     !isActive &&
-                        `text-zinc-600 dark:text-zinc-200 hover:text-zinc-900 dark:hover:text-white`
+                        `text-zinc-600 dark:text-zinc-300 hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black`
                 )
             }
             to={to}
@@ -110,8 +108,8 @@ function StaticNavLink({
         <a
             className={cx(
                 sharedLinkClasses,
-                `transition-colors duration-200 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-900 py-3 px-4 text-zinc-600 dark:text-zinc-200 hover:text-zinc-900 dark:hover:text-white`,
-                `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950`
+                `transition-colors duration-150 py-2 px-3 text-zinc-600 dark:text-zinc-300 hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black`,
+                `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950`
             )}
             href={to}
             {...rest}
@@ -139,7 +137,7 @@ export default function WrapperRoute() {
 
     return (
         <>
-            <header className="py-8">
+            <header className="py-6 border-b-2 border-black dark:border-zinc-200">
                 <Container>
                     <nav>
                         <ul className="hidden lg:flex items-center gap-4 md:gap-8">
@@ -147,9 +145,9 @@ export default function WrapperRoute() {
                                 <Link
                                     to="/"
                                     aria-label="Return to home page"
-                                    className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 rounded-lg"
+                                    className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950"
                                 >
-                                    <Logo className="fill-zinc-700 h-16 dark:fill-white" />
+                                    <Logo className="fill-black h-14 dark:fill-white" />
                                 </Link>
                             </li>
                             {NAV_ITEMS.map((item) => (
@@ -172,7 +170,7 @@ export default function WrapperRoute() {
                         <ul className="lg:hidden flex justify-between">
                             <li>
                                 <Link to="/" aria-label="Return to home page">
-                                    <Logo className="fill-zinc-700 h-12 dark:fill-white" />
+                                    <Logo className="fill-black h-12 dark:fill-white" />
                                 </Link>
                             </li>
                             <li>
@@ -199,7 +197,7 @@ export default function WrapperRoute() {
                                             to="/"
                                             aria-label="Return to home page"
                                         >
-                                            <Logo className="fill-zinc-700 h-12 dark:fill-white" />
+                                            <Logo className="fill-black h-12 dark:fill-white" />
                                         </Link>
                                         <Button
                                             variant="ghost"
@@ -258,27 +256,24 @@ export default function WrapperRoute() {
                     <Outlet />
                 </Container>
             </main>
-            <footer className="py-0 md:py-8">
-                <Container className="flex flex-col items-center gap-4">
-                    <div className="flex w-full items-center justify-between my-12">
-                        <div className={`flex-grow ${BorderStyles.BOTTOM}`} />
-                        <Flex className="px-4 text-center items-center">
-                            <p className="inline-block">
-                                ✌🏻 Made in Austin, TX{' '}
-                            </p>
+            <footer className="border-t-2 border-black dark:border-zinc-200 mt-16">
+                <Container className="py-8">
+                    <Flex className="items-center justify-between font-mono text-xs uppercase tracking-[0.2em] text-zinc-600 dark:text-zinc-400">
+                        <span>Seth Davis</span>
+                        <Flex className="items-center gap-2">
+                            <span>✌🏻 Made in Austin, TX</span>
                             <img
-                                className="h-5 w-5"
+                                className="h-4 w-4"
                                 src="https://res.cloudinary.com/setholito/image/upload/v1/portfolio/flag-of-texas-small.svg"
                                 alt="Texas flag"
                             />
                         </Flex>
-                        <div className={`flex-grow ${BorderStyles.BOTTOM}`} />
-                    </div>
+                    </Flex>
                 </Container>
             </footer>
-            <div className="hidden md:block fixed right-0 bottom-0 p-8">
-                <span className="bg-zinc-300 dark:bg-zinc-800 p-4 border border-zinc-700 text-zinc-700 dark:text-white rounded-lg text-sm">
-                    Navigate via <KeyboardShortcut keys={['Cmd', 'K']} />
+            <div className="hidden md:block fixed right-6 bottom-6">
+                <span className="bg-white dark:bg-zinc-950 py-2.5 px-4 border-2 border-black dark:border-zinc-200 text-black dark:text-white font-mono text-xs uppercase tracking-[0.15em] shadow-[4px_4px_0_0_var(--color-black)] dark:shadow-[4px_4px_0_0_var(--color-zinc-200)] inline-flex items-center gap-2">
+                    Navigate <KeyboardShortcut keys={['Cmd', 'K']} />
                 </span>
             </div>
         </>

--- a/app/routes/wrapper.tsx
+++ b/app/routes/wrapper.tsx
@@ -7,7 +7,7 @@ import { Flex } from '~/components/Flex';
 import { KeyboardShortcut } from '~/components/KeyboardShortcut';
 import { Logo } from '~/components/logos/SethDavisLogo';
 
-const sharedLinkClasses = `text-3xl md:text-sm font-mono uppercase tracking-[0.15em]`;
+const sharedLinkClasses = `text-3xl md:text-sm font-medium`;
 
 interface NavItem {
     type: 'internal' | 'external';
@@ -83,9 +83,10 @@ function AppNavLink({ to, children, ariaLabel, onClick }: AppNavLinkProps) {
                     sharedLinkClasses,
                     `transition-colors duration-150 py-2 px-3`,
                     `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950`,
-                    isActive && `bg-primary-400 text-black font-semibold`,
+                    isActive &&
+                        `bg-primary-500/15 text-primary-800 dark:text-primary-300 rounded-lg`,
                     !isActive &&
-                        `text-zinc-600 dark:text-zinc-300 hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black`
+                        `text-zinc-600 dark:text-zinc-400 rounded-lg hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800/70 dark:hover:text-zinc-100`
                 )
             }
             to={to}
@@ -108,7 +109,7 @@ function StaticNavLink({
         <a
             className={cx(
                 sharedLinkClasses,
-                `transition-colors duration-150 py-2 px-3 text-zinc-600 dark:text-zinc-300 hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black`,
+                `transition-colors duration-150 py-2 px-3 rounded-lg text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800/70 dark:hover:text-zinc-100`,
                 `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ring-offset-white dark:focus-visible:ring-primary-400 dark:ring-offset-zinc-950`
             )}
             href={to}
@@ -137,7 +138,7 @@ export default function WrapperRoute() {
 
     return (
         <>
-            <header className="py-6 border-b-2 border-black dark:border-zinc-200">
+            <header className="py-6 border-b border-zinc-200 dark:border-zinc-800">
                 <Container>
                     <nav>
                         <ul className="hidden lg:flex items-center gap-4 md:gap-8">
@@ -256,9 +257,9 @@ export default function WrapperRoute() {
                     <Outlet />
                 </Container>
             </main>
-            <footer className="border-t-2 border-black dark:border-zinc-200 mt-16">
+            <footer className="border-t border-zinc-200 dark:border-zinc-800 mt-16">
                 <Container className="py-8">
-                    <Flex className="items-center justify-between font-mono text-xs uppercase tracking-[0.2em] text-zinc-600 dark:text-zinc-400">
+                    <Flex className="items-center justify-between text-xs text-zinc-500">
                         <span>Seth Davis</span>
                         <Flex className="items-center gap-2">
                             <span>✌🏻 Made in Austin, TX</span>
@@ -272,7 +273,7 @@ export default function WrapperRoute() {
                 </Container>
             </footer>
             <div className="hidden md:block fixed right-6 bottom-6">
-                <span className="bg-white dark:bg-zinc-950 py-2.5 px-4 border-2 border-black dark:border-zinc-200 text-black dark:text-white font-mono text-xs uppercase tracking-[0.15em] shadow-[4px_4px_0_0_var(--color-black)] dark:shadow-[4px_4px_0_0_var(--color-zinc-200)] inline-flex items-center gap-2">
+                <span className="rounded-lg bg-white dark:bg-zinc-900 py-2.5 px-4 border border-zinc-200 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300 text-xs shadow-sm inline-flex items-center gap-2">
                     Navigate <KeyboardShortcut keys={['Cmd', 'K']} />
                 </span>
             </div>

--- a/app/schemas/contact.ts
+++ b/app/schemas/contact.ts
@@ -18,7 +18,10 @@ export const contactFormSchema = z.object({
         .max(320, 'Email is too long')
         .email('Please enter a valid email address'),
     note: z.string().trim().max(2000, 'Note is too long').optional(),
-    offer: z.string().trim().max(100, 'Offer is too long').optional()
+    offer: z.string().trim().max(100, 'Offer is too long').optional(),
+    company: z.string().trim().max(200, 'Company is too long').optional(),
+    budget: z.string().trim().max(50, 'Budget is too long').optional(),
+    timeline: z.string().trim().max(50, 'Timeline is too long').optional()
 });
 
 export type ContactFormData = z.infer<typeof contactFormSchema>;
@@ -33,7 +36,10 @@ export function validateContactForm(formData: FormData):
         lastName: formData.get('lastName'),
         email: formData.get('email'),
         note: formData.get('note') || undefined,
-        offer: formData.get('offer') || undefined
+        offer: formData.get('offer') || undefined,
+        company: formData.get('company') || undefined,
+        budget: formData.get('budget') || undefined,
+        timeline: formData.get('timeline') || undefined
     });
 
     if (result.success) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,11 +6,27 @@ import remarkGfm from 'remark-gfm';
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
 import serverAdapter from 'hono-react-router-adapter/vite';
 import { defaultOptions } from '@hono/vite-dev-server';
-import { defineConfig } from 'vite';
+import { defineConfig, searchForWorkspaceRoot } from 'vite';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+// In a git worktree, node_modules resolves into the main checkout, which sits
+// outside Vite's default fs sandbox and 403s the client entry (breaking
+// hydration). Allow the directory dependencies actually resolve from.
+const require = createRequire(import.meta.url);
+const sharedNodeModules = path.resolve(
+    path.dirname(require.resolve('@react-router/dev/package.json')),
+    '../..'
+);
 
 export default defineConfig({
     resolve: {
         tsconfigPaths: true
+    },
+    server: {
+        fs: {
+            allow: [searchForWorkspaceRoot(process.cwd()), sharedNodeModules]
+        }
     },
     plugins: [
         tailwindcss(),


### PR DESCRIPTION
## What's in here

**Full visual redesign (warm studio minimal)**
- Fraunces display serif + Archivo + JetBrains Mono type stack (previously no web fonts loaded)
- New OKLCH palette: muted amber primary, sage secondary, clay tertiary, warm-tinted zinc neutrals
- Hairline borders, soft radii, sentence-case labels, amber selection/focus rings
- All components and routes restyled; verified by screenshot across desktop/tablet/mobile

**Services reposition** (zero inbound on the old priced offers)
- New 4-offer lineup: Marketing sites, Design systems, AI prototyping, Fractional design technologist (retainer)
- All pricing removed; primary CTA is a free TidyCal scope call
- Inquiry form gains company/budget/timeline qualifiers (folded into Airtable Note)
- 301 redirects for old offer slugs, FAQPage JSON-LD, services entry point on home

**Fixes**
- Dev-only: git worktrees broke hydration entirely (Vite fs.allow 403 on the shared node_modules client entry)
- Tablet: hero name on one line, project/slide grids single-column until lg
- Light-mode contrast bugs in ServiceLanding, inverted Shiki themes in CodeBlock

## Verification
- Typecheck + production build clean (prerender succeeds)
- 301s verified via curl; form validation verified against the action
- Screenshot-verified on all key routes at desktop/tablet/mobile widths

Note: merging deploys to Railway production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)